### PR TITLE
Add MkDocs documentation and GitHub Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,21 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-material mkdocstrings[python]
+      - name: Build documentation
+        run: mkdocs build --strict
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,3 @@
+# API Reference
+
+::: pypaperretriever

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,10 @@
+# FAQ
+
+## How do I install the library?
+See the [Installation](installation.md) guide.
+
+## Can I use PyPaperRetriever offline?
+No. The library queries online databases and requires an internet connection.
+
+## Where can I report issues?
+File bug reports and feature requests on [GitHub](https://github.com/your-username/pypaperretriever/issues).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# PyPaperRetriever
+
+Welcome to the official documentation for **PyPaperRetriever**, a Python library for retrieving and processing academic papers.
+
+Use the navigation on the left to explore the docs or jump to a section below:
+
+- [Installation](installation.md)
+- [Quickstart](quickstart.md)
+- [API Reference](api.md)
+- [FAQ](faq.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,13 @@
+# Installation
+
+Install **PyPaperRetriever** with pip:
+
+```bash
+pip install pypaperretriever
+```
+
+To work on the documentation locally:
+
+```bash
+pip install mkdocs mkdocs-material mkdocstrings[python]
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,64 @@
+# Quickstart
+
+This tutorial shows how to fetch a paper with **PyPaperRetriever** and demonstrates writing clear docstrings.
+
+## Fetch a paper
+
+```python
+from pypaperretriever import Retriever
+
+retriever = Retriever()
+paper = retriever.fetch("10.1038/nature12373")
+print(paper.title)
+```
+
+## Docstring examples
+
+```python
+def calculate_sum(values):
+    """Compute the sum of numeric values.
+
+    Args:
+        values (Iterable[float]): Numbers to be summed. An empty iterable returns ``0``.
+
+    Returns:
+        float: The total of all provided values.
+
+    Raises:
+        TypeError: If any element in ``values`` is not numeric.
+    """
+    return sum(values)
+
+
+class DataProcessor:
+    """Process and analyze numeric datasets.
+
+    Attributes:
+        scale (float): Factor applied to each element before aggregation.
+    """
+
+    def __init__(self, scale: float = 1.0):
+        """Create a new processor.
+
+        Args:
+            scale (float, optional): Multiplier for data values. Defaults to ``1.0``.
+        """
+        self.scale = scale
+
+    def process(self, data):
+        """Scale and average a sequence of numbers.
+
+        Args:
+            data (Iterable[float]): Input values to process.
+
+        Returns:
+            float: Mean of the scaled values.
+
+        Raises:
+            ValueError: If ``data`` is empty.
+        """
+        if not data:
+            raise ValueError("data must contain at least one element")
+        scaled = [x * self.scale for x in data]
+        return sum(scaled) / len(scaled)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,33 @@
+site_name: PyPaperRetriever
+site_description: Documentation for PyPaperRetriever
+site_url: https://your-username.github.io/pypaperretriever/
+repo_url: https://github.com/your-username/pypaperretriever
+repo_name: your-username/pypaperretriever
+
+theme:
+  name: material
+  features:
+    - navigation.expand
+    - navigation.sections
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: true
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Quickstart: quickstart.md
+  - API Reference: api.md
+  - FAQ: faq.md
+
+extra:
+  version: 0.1.0
+markdown_extensions:
+  - admonition
+  - codehilite


### PR DESCRIPTION
## Summary
- set up MkDocs config with Material theme and mkdocstrings for API docs
- add basic documentation pages and placeholders
- add GitHub Actions workflow to deploy docs to GitHub Pages

## Testing
- `pip install -r requirements.txt`
- `pip install mkdocs mkdocs-material mkdocstrings[python]` *(failed: Could not find a version that satisfies the requirement mkdocs)*
- `mkdocs build` *(command not found)*
- `pytest` *(ImportError: libGL.so.1 cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6896cf9b57b0832c8a07eba59d22d4ff