### PR TITLE
Add MkDocs documentation and GitHub Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,21 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-material mkdocstrings[python]
+      - name: Build documentation
+        run: mkdocs build --strict
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,3 @@
+# API Reference
+
+::: pypaperretriever

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,10 @@
+# FAQ
+
+## How do I install the library?
+See the [Installation](installation.md) guide.
+
+## Can I use PyPaperRetriever offline?
+No. The library queries online databases and requires an internet connection.
+
+## Where can I report issues?
+File bug reports and feature requests on [GitHub](https://github.com/your-username/pypaperretriever/issues).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# PyPaperRetriever
+
+Welcome to the official documentation for **PyPaperRetriever**, a Python library for retrieving and processing academic papers.
+
+Use the navigation on the left to explore the docs or jump to a section below:
+
+- [Installation](installation.md)
+- [Quickstart](quickstart.md)
+- [API Reference](api.md)
+- [FAQ](faq.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,13 @@
+# Installation
+
+Install **PyPaperRetriever** with pip:
+
+```bash
+pip install pypaperretriever
+```
+
+To work on the documentation locally:
+
+```bash
+pip install mkdocs mkdocs-material mkdocstrings[python]
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,64 @@
+# Quickstart
+
+This tutorial shows how to fetch a paper with **PyPaperRetriever** and demonstrates writing clear docstrings.
+
+## Fetch a paper
+
+```python
+from pypaperretriever import Retriever
+
+retriever = Retriever()
+paper = retriever.fetch("10.1038/nature12373")
+print(paper.title)
+```
+
+## Docstring examples
+
+```python
+def calculate_sum(values):
+    """Compute the sum of numeric values.
+
+    Args:
+        values (Iterable[float]): Numbers to be summed. An empty iterable returns ``0``.
+
+    Returns:
+        float: The total of all provided values.
+
+    Raises:
+        TypeError: If any element in ``values`` is not numeric.
+    """
+    return sum(values)
+
+
+class DataProcessor:
+    """Process and analyze numeric datasets.
+
+    Attributes:
+        scale (float): Factor applied to each element before aggregation.
+    """
+
+    def __init__(self, scale: float = 1.0):
+        """Create a new processor.
+
+        Args:
+            scale (float, optional): Multiplier for data values. Defaults to ``1.0``.
+        """
+        self.scale = scale
+
+    def process(self, data):
+        """Scale and average a sequence of numbers.
+
+        Args:
+            data (Iterable[float]): Input values to process.
+
+        Returns:
+            float: Mean of the scaled values.
+
+        Raises:
+            ValueError: If ``data`` is empty.
+        """
+        if not data:
+            raise ValueError("data must contain at least one element")
+        scaled = [x * self.scale for x in data]
+        return sum(scaled) / len(scaled)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,33 @@
+site_name: PyPaperRetriever
+site_description: Documentation for PyPaperRetriever
+site_url: https://your-username.github.io/pypaperretriever/
+repo_url: https://github.com/your-username/pypaperretriever
+repo_name: your-username/pypaperretriever
+
+theme:
+  name: material
+  features:
+    - navigation.expand
+    - navigation.sections
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: true
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Quickstart: quickstart.md
+  - API Reference: api.md
+  - FAQ: faq.md
+
+extra:
+  version: 0.1.0
+markdown_extensions:
+  - admonition
+  - codehilite

--- a/pypaperretriever/paper_tracker.py
+++ b/pypaperretriever/paper_tracker.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from typing import List, Dict, Any, Optional
 from .reference_retriever import ReferenceRetriever
 
 class PaperTracker:
@@ -32,7 +33,14 @@ class PaperTracker:
         - parent_identifiers: List of papers that cite this paper
     """
 
-    def __init__(self, email, max_upstream_generations=1, max_downstream_generations=1, doi=None, pmid=None):
+    def __init__(
+        self,
+        email: str,
+        max_upstream_generations: int = 1,
+        max_downstream_generations: int = 1,
+        doi: Optional[str] = None,
+        pmid: Optional[str] = None,
+    ) -> None:
         """
         Initialize the PaperTracker with either a DOI or PMID.
 
@@ -64,7 +72,7 @@ class PaperTracker:
         self.processed_upstream = set()
         self.processed_downstream = set()
 
-    def go_upstream(self, doi=None, pmid=None):
+    def go_upstream(self, doi: Optional[str] = None, pmid: Optional[str] = None) -> List[Dict[str, Any]]:
         """
         Fetch references for a given paper.
 
@@ -73,13 +81,13 @@ class PaperTracker:
             pmid (str, optional): PubMed ID of the paper
 
         Returns:
-            list: List of dictionaries containing reference paper metadata
+            List[Dict[str, Any]]: List of dictionaries containing reference paper metadata
         """
         print(f"[PaperTracker] Going upstream for DOI: {doi}, PMID: {pmid}")
         retriever = ReferenceRetriever(email=self.email, doi=doi, pmid=pmid)
         return retriever.fetch_references()
 
-    def go_downstream(self, doi=None, pmid=None):
+    def go_downstream(self, doi: Optional[str] = None, pmid: Optional[str] = None) -> List[Dict[str, Any]]:
         """
         Fetch papers that cite the given paper.
 
@@ -88,13 +96,13 @@ class PaperTracker:
             pmid (str, optional): PubMed ID of the paper
 
         Returns:
-            list: List of dictionaries containing citing paper metadata
+            List[Dict[str, Any]]: List of dictionaries containing citing paper metadata
         """
         print(f"[PaperTracker] Going downstream for DOI: {doi}, PMID: {pmid}")
         retriever = ReferenceRetriever(email=self.email, doi=doi, pmid=pmid)
         return retriever.fetch_cited_by()
 
-    def track_paper(self):
+    def track_paper(self) -> pd.DataFrame:
         """
         Build the complete citation network around the root paper.
         
@@ -110,7 +118,13 @@ class PaperTracker:
         print("[PaperTracker] Tracking process completed.")
         return self.df
 
-    def _track_upstream(self, doi, pmid, generation, parent_id):
+    def _track_upstream(
+        self,
+        doi: Optional[str],
+        pmid: Optional[str],
+        generation: int,
+        parent_id: Optional[str],
+    ) -> None:
         """
         Recursively track references up to max_upstream_generations.
 
@@ -175,7 +189,13 @@ class PaperTracker:
                 self.df.at[idx[0], 'children_identifiers'] = current_children + [ref_id]
                 print(f"[PaperTracker] Updated children_identifiers for Paper ID: {paper_id}")
 
-    def _track_downstream(self, doi, pmid, generation, parent_id):
+    def _track_downstream(
+        self,
+        doi: Optional[str],
+        pmid: Optional[str],
+        generation: int,
+        parent_id: Optional[str],
+    ) -> None:
         """
         Recursively track citations up to max_downstream_generations.
 
@@ -240,7 +260,7 @@ class PaperTracker:
                 self.df.at[idx[0], 'children_identifiers'] = current_children + [cite_id]
                 print(f"[PaperTracker] Updated children_identifiers for Paper ID: {paper_id}")
 
-    def _get_paper_metadata(self, doi, pmid):
+    def _get_paper_metadata(self, doi: Optional[str], pmid: Optional[str]) -> Dict[str, Any]:
         """
         Fetch metadata for a given paper.
 
@@ -249,7 +269,7 @@ class PaperTracker:
             pmid (str): PubMed ID of the paper
 
         Returns:
-            dict: Paper metadata including doi, pmid, title, authors, and year
+            Dict[str, Any]: Paper metadata including doi, pmid, title, authors, and year
         """
         print(f"[PaperTracker] Fetching metadata for DOI: {doi}, PMID: {pmid}")
         retriever = ReferenceRetriever(email=self.email, doi=doi, pmid=pmid)

--- a/pypaperretriever/reference_retriever.py
+++ b/pypaperretriever/reference_retriever.py
@@ -1,6 +1,7 @@
 import requests
 from Bio import Entrez
 import re
+from typing import List, Dict, Any, Optional
 
 from .utils import doi_to_pmid
 
@@ -11,7 +12,13 @@ class ReferenceRetriever:
     Fetches data from multiple sources including PubMed, Europe PMC, and CrossRef.
     """
     
-    def __init__(self, email, doi=None, pmid=None, standardize=True):
+    def __init__(
+        self,
+        email: str,
+        doi: Optional[str] = None,
+        pmid: Optional[str] = None,
+        standardize: bool = True,
+    ) -> None:
         """
         Initialize the retriever with either DOI or PMID.
 
@@ -32,12 +39,12 @@ class ReferenceRetriever:
             self.pmid = doi_to_pmid(self.doi, self.email)
             print(f"[ReferenceRetriever] Converted DOI {self.doi} to PMID: {self.pmid}")
 
-    def fetch_references(self):
+    def fetch_references(self) -> List[Dict[str, Any]]:
         """
         Fetch references for the given DOI or PMID using multiple sources.
 
         Returns:
-            list: List of dictionaries containing reference metadata. Empty list if none found.
+            List[Dict[str, Any]]: List of dictionaries containing reference metadata. Empty list if none found.
 
         Raises:
             ValueError: If neither DOI nor PMID is provided.
@@ -53,12 +60,12 @@ class ReferenceRetriever:
         print(f"[ReferenceRetriever] Found {len(references)} references.")
         return references
 
-    def fetch_cited_by(self):
+    def fetch_cited_by(self) -> List[Dict[str, Any]]:
         """
         Fetch articles that cite the given DOI or PMID.
 
         Returns:
-            list: List of dictionaries containing citing article metadata. Empty list if none found.
+            List[Dict[str, Any]]: List of dictionaries containing citing article metadata. Empty list if none found.
 
         Raises:
             ValueError: If PMID conversion fails or is not provided.
@@ -81,12 +88,12 @@ class ReferenceRetriever:
         print(f"[ReferenceRetriever] Found {len(cited_by)} citing articles.")
         return cited_by
 
-    def get_paper_metadata(self):
+    def get_paper_metadata(self) -> Dict[str, Any]:
         """
         Fetch metadata for the paper identified by DOI or PMID.
 
         Returns:
-            dict: Paper metadata including DOI, PMID, title, authors, and year. Empty dict if not found.
+            Dict[str, Any]: Paper metadata including DOI, PMID, title, authors, and year. Empty dict if not found.
         """
         print(f"[ReferenceRetriever] Fetching metadata for DOI: {self.doi}, PMID: {self.pmid}")
         if self.pmid:
@@ -112,12 +119,12 @@ class ReferenceRetriever:
                 print(f"[ReferenceRetriever] Unable to convert DOI {self.doi} to PMID.")
         return {}
 
-    def _find_references(self):
+    def _find_references(self) -> List[Dict[str, Any]]:
         """
         Find references using multiple sources (PubMed, Europe PMC, CrossRef).
 
         Returns:
-            list: Combined list of references from all sources.
+            List[Dict[str, Any]]: Combined list of references from all sources.
         """
         print("[ReferenceRetriever] Finding references using multiple sources.")
         references = []
@@ -146,12 +153,12 @@ class ReferenceRetriever:
             return self._standardize_references(references)
         return references
 
-    def _find_cited_by(self):
+    def _find_cited_by(self) -> List[Dict[str, Any]]:
         """
         Find citing articles using multiple sources (PubMed, Europe PMC).
 
         Returns:
-            list: Combined list of citing articles from all sources.
+            List[Dict[str, Any]]: Combined list of citing articles from all sources.
         """
         print("[ReferenceRetriever] Finding citing articles using multiple sources.")
         cited_by = []
@@ -170,7 +177,7 @@ class ReferenceRetriever:
         print(f"[ReferenceRetriever] Total citing articles found: {len(cited_by)}")
         return cited_by
 
-    def get_references_europe(self, pmid):
+    def get_references_europe(self, pmid: str) -> List[Dict[str, Any]]:
         """
         Fetch references from Europe PMC API.
 
@@ -178,7 +185,7 @@ class ReferenceRetriever:
             pmid (str): PubMed ID to fetch references for
 
         Returns:
-            list: References found in Europe PMC. Empty list if none found or on error.
+            List[Dict[str, Any]]: References found in Europe PMC. Empty list if none found or on error.
         """
         url = f"https://www.ebi.ac.uk/europepmc/webservices/rest/MED/{pmid}/references?page=1&pageSize=1000&format=json"
         print(f"[ReferenceRetriever] Requesting Europe PMC references from URL: {url}")
@@ -196,7 +203,7 @@ class ReferenceRetriever:
             print(f"[ReferenceRetriever] Error fetching references from Europe PMC for PMID {pmid}: {e}")
             return []
 
-    def get_references_entrez_pubmed(self, pmid):
+    def get_references_entrez_pubmed(self, pmid: str) -> List[Dict[str, Any]]:
         """
         Fetch references from PubMed using Entrez.
 
@@ -204,7 +211,7 @@ class ReferenceRetriever:
             pmid (str): PubMed ID to fetch references for
 
         Returns:
-            list: References found in PubMed. Empty list if none found or on error.
+            List[Dict[str, Any]]: References found in PubMed. Empty list if none found or on error.
         """
         Entrez.email = self.email
         print(f"[ReferenceRetriever] Requesting Entrez PubMed references for PMID: {pmid}")
@@ -227,7 +234,7 @@ class ReferenceRetriever:
             print(f"[ReferenceRetriever] Error fetching references from PubMed for PMID {pmid}: {e}")
             return []
 
-    def get_references_crossref(self, doi):
+    def get_references_crossref(self, doi: str) -> List[Dict[str, Any]]:
         """
         Fetch references from CrossRef API.
 
@@ -235,7 +242,7 @@ class ReferenceRetriever:
             doi (str): DOI to fetch references for
 
         Returns:
-            list: References found in CrossRef. Empty list if none found or on error.
+            List[Dict[str, Any]]: References found in CrossRef. Empty list if none found or on error.
         """
         url = f"https://api.crossref.org/works/{doi}"
         print(f"[ReferenceRetriever] Requesting CrossRef references from URL: {url}")
@@ -253,7 +260,7 @@ class ReferenceRetriever:
             print(f"[ReferenceRetriever] Error fetching references from CrossRef for DOI {doi}: {e}")
             return []
 
-    def get_citing_articles_europe(self, pmid):
+    def get_citing_articles_europe(self, pmid: str) -> List[Dict[str, Any]]:
         """
         Fetch citing articles from Europe PMC API.
 
@@ -261,7 +268,7 @@ class ReferenceRetriever:
             pmid (str): PubMed ID to fetch citations for
 
         Returns:
-            list: Citing articles found in Europe PMC. Empty list if none found or on error.
+            List[Dict[str, Any]]: Citing articles found in Europe PMC. Empty list if none found or on error.
         """
         url = f"https://www.ebi.ac.uk/europepmc/webservices/rest/MED/{pmid}/citations?format=json"
         print(f"[ReferenceRetriever] Requesting Europe PMC citing articles from URL: {url}")
@@ -279,7 +286,7 @@ class ReferenceRetriever:
             print(f"[ReferenceRetriever] Error fetching citing articles from Europe PMC for PMID {pmid}: {e}")
             return []
 
-    def get_citing_articles_pubmed(self, pmid):
+    def get_citing_articles_pubmed(self, pmid: str) -> List[Dict[str, Any]]:
         """
         Fetch citing articles from PubMed using Entrez.
 
@@ -287,7 +294,7 @@ class ReferenceRetriever:
             pmid (str): PubMed ID to fetch citations for
 
         Returns:
-            list: Citing articles found in PubMed. Empty list if none found or on error.
+            List[Dict[str, Any]]: Citing articles found in PubMed. Empty list if none found or on error.
         """
         Entrez.email = self.email
         print(f"[ReferenceRetriever] Requesting PubMed citing articles for PMID: {pmid}")
@@ -310,7 +317,7 @@ class ReferenceRetriever:
             print(f"[ReferenceRetriever] Error fetching citing articles from PubMed for PMID {pmid}: {e}")
             return []
 
-    def _fetch_articles_details(self, pmids):
+    def _fetch_articles_details(self, pmids: List[str]) -> List[Dict[str, Any]]:
         """
         Fetch detailed metadata for multiple PMIDs from PubMed.
 
@@ -318,7 +325,7 @@ class ReferenceRetriever:
             pmids (list): List of PubMed IDs to fetch details for
 
         Returns:
-            list: Article details for each PMID. Empty list if none found or on error.
+            List[Dict[str, Any]]: Article details for each PMID. Empty list if none found or on error.
         """
         Entrez.email = self.email
         pmid_string = ",".join(pmids)
@@ -335,13 +342,13 @@ class ReferenceRetriever:
             return []
 
 
-    def _parse_europe_references(self, references):
+    def _parse_europe_references(self, references: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
         Parses a list of references from Europe PMC and extracts relevant information.
         Args:
             references (list): A list of reference dictionaries obtained from Europe PMC.
         Returns:
-            list: A list of dictionaries, where each dictionary contains parsed
+            List[Dict[str, Any]]: A list of dictionaries, where each dictionary contains parsed
                     information about a single reference, including authors, title,
                     journal, year, and DOI.
         """
@@ -360,7 +367,7 @@ class ReferenceRetriever:
         print(f"[ReferenceRetriever] Parsed {len(parsed_references)} Europe PMC references.")
         return parsed_references
 
-    def _parse_pubmed_references(self, references):
+    def _parse_pubmed_references(self, references: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
         Parses a list of PubMed references and extracts relevant information.
         This method processes a list of references obtained from Entrez PubMed,
@@ -370,7 +377,7 @@ class ReferenceRetriever:
             references (list): A list of reference dictionaries, where each dictionary
                                contains information about a single reference.
         Returns:
-            list: A list of dictionaries, where each dictionary contains parsed
+            List[Dict[str, Any]]: A list of dictionaries, where each dictionary contains parsed
                   information about a single reference, including citation, DOI,
                   authors, PMID, and PMCID if available.
         """
@@ -408,13 +415,13 @@ class ReferenceRetriever:
         print(f"[ReferenceRetriever] Parsed {len(parsed_references)} Entrez PubMed references.")
         return parsed_references
 
-    def _parse_crossref_references(self, references):
+    def _parse_crossref_references(self, references: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
         Parses a list of references from CrossRef and extracts relevant information.
         Args:  
             references (list): A list of reference dictionaries obtained from CrossRef.
         Returns:
-            list: A list of dictionaries, where each dictionary contains parsed
+            List[Dict[str, Any]]: A list of dictionaries, where each dictionary contains parsed
                     information about a single reference, including authors, title,
                     journal, year, and DOI.
         """
@@ -432,13 +439,13 @@ class ReferenceRetriever:
         print(f"[ReferenceRetriever] Parsed {len(parsed_references)} CrossRef references.")
         return parsed_references
 
-    def _parse_pubmed_articles(self, records):
+    def _parse_pubmed_articles(self, records: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
         Parses a list of PubMed articles and extracts relevant information.
         Args:
             records (dict): A dictionary containing PubMed articles data.
-        Returns:    
-            list: A list of dictionaries, where each dictionary contains parsed
+        Returns:
+            List[Dict[str, Any]]: A list of dictionaries, where each dictionary contains parsed
                     information about a single article, including authors, title,
                     journal, year, and DOI.
         """
@@ -460,7 +467,7 @@ class ReferenceRetriever:
         print(f"[ReferenceRetriever] Parsed details for {len(parsed_articles)} PubMed articles.")
         return parsed_articles
 
-    def _get_author_list(self, authors):
+    def _get_author_list(self, authors: List[Dict[str, Any]]) -> str:
         """
         Generate a comma-separated list of author names.
         Args:
@@ -476,7 +483,7 @@ class ReferenceRetriever:
                 author_list.append(name)
         return ', '.join(author_list)
 
-    def _get_pub_date_year(self, pub_date):
+    def _get_pub_date_year(self, pub_date: Dict[str, Any]) -> str:
         """
         Extract the year from the publication date data.
         """
@@ -489,9 +496,15 @@ class ReferenceRetriever:
                 return match.group(0)
         return ''
 
-    def _parse_europe_cited_by(self, cited_by):
+    def _parse_europe_cited_by(self, cited_by: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
-        Parses a list of citing articles from Europe PMC and extracts relevant information.
+        Parse citing articles from Europe PMC and extract relevant information.
+
+        Args:
+            cited_by (List[Dict[str, Any]]): Raw citing article data from Europe PMC.
+
+        Returns:
+            List[Dict[str, Any]]: Parsed citing article metadata.
         """
         print("[ReferenceRetriever] Parsing Europe PMC citing articles.")
         parsed_citations = []
@@ -508,9 +521,15 @@ class ReferenceRetriever:
         print(f"[ReferenceRetriever] Parsed {len(parsed_citations)} Europe PMC citing articles.")
         return parsed_citations
 
-    def _format_crossref_authors(self, authors):
+    def _format_crossref_authors(self, authors: Optional[List[Dict[str, Any]]]) -> str:
         """
         Format authors list from CrossRef API response.
+
+        Args:
+            authors (Optional[List[Dict[str, Any]]]): Author entries from CrossRef.
+
+        Returns:
+            str: Comma-separated author names.
         """
         if not authors:
             return ''
@@ -521,15 +540,15 @@ class ReferenceRetriever:
         print(f"[ReferenceRetriever] Formatted {len(formatted_authors)} CrossRef authors.")
         return ', '.join(formatted_authors)
     
-    def _standardize_references(self, references):
+    def _standardize_references(self, references: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
-        Standardizes reference metadata to match the required format.
+        Standardize reference metadata to match the required format.
 
-        Parameters:
-            references (list): List of raw reference dictionaries.
+        Args:
+            references (List[Dict[str, Any]]): List of raw reference dictionaries.
 
         Returns:
-            list: List of standardized reference dictionaries.
+            List[Dict[str, Any]]: List of standardized reference dictionaries.
         """
         standard_keys = ['doi', 'pmid', 'pmcid', 'title', 'authors']
         standardized_refs = []


### PR DESCRIPTION
## Summary
- set up MkDocs config with Material theme and mkdocstrings for API docs
- add basic documentation pages and placeholders
- add GitHub Actions workflow to deploy docs to GitHub Pages
- add return type hints and richer docstrings for `PaperTracker` and `ReferenceRetriever` to satisfy mkdocstrings strict mode

## Testing
- `pip install -r requirements.txt`
- `pip install mkdocs mkdocs-material mkdocstrings[python]` *(failed: Could not find a version that satisfies the requirement mkdocs)*
- `mkdocs build --strict` *(command not found: mkdocs)*
- `pytest` *(ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6896cf9b57b0832c8a07eba59d22d4ff