### PR TITLE
Short circuit 403 errors

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7,4 +7,5 @@ The public API is organized by module (mirrors the package layout):
 - `image_extractor` — extract figures from PDFs
 - `reference_retriever` — fetch references and cited-by
 - `paper_tracker` — upstream/downstream citation network
+- `http_client` — HTTP client with optional robots.txt and Crawl-Delay support
 - `utils` — small helpers for power users

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -1,16 +1,18 @@
 # HTTP Client & Polite Crawling
 
-PyPaperRetriever includes an `HttpClient` that wraps `requests.get()` with two
-opt-in politeness features:
+PyPaperRetriever includes an `HttpClient` that wraps `requests.get()` with
+three features for polite and efficient crawling:
 
 1. **robots.txt / Crawl-Delay** — check each domain's `robots.txt` before
    fetching and respect its `Crawl-Delay` directive.
 2. **HTTP 429 retry** — automatically wait and retry when a server replies with
    *429 Too Many Requests*.
+3. **403 domain suppression** — remember domains that return *403 Forbidden*
+   and short-circuit subsequent requests to the same domain, avoiding redundant
+   network round-trips during bulk downloads.
 
-By default robots.txt support is **off** (zero overhead) while 429 retry is
-**on** (safe default — it only activates when a server explicitly asks you to
-slow down).
+By default robots.txt support is **off** (zero overhead) while 429 retry and
+403 suppression are **on**.
 
 ## Quick examples
 
@@ -113,6 +115,55 @@ client = HttpClient(honor_retry_after=False)
 
 ---
 
+## 403 Forbidden domain suppression
+
+When `suppress_on_403=True` (the default) and a server responds with **403
+Forbidden**, `HttpClient` records that domain in an internal blocklist.  All
+subsequent requests to the same domain are immediately returned as a synthetic
+403 response *without making a network request*.  This dramatically speeds up
+bulk downloads where certain publishers consistently deny access.
+
+### Exempt domains
+
+Some domains — notably `doi.org` and `dx.doi.org` — act purely as redirectors.
+A 403 from `doi.org` actually originates at the *destination* publisher, not at
+`doi.org` itself.  These domains are **exempt** from suppression and will never
+be blocklisted.
+
+### Inspecting the blocklist
+
+The `suppressed_domains` property returns a copy of the current blocklist:
+
+```python
+client = HttpClient()
+# ... after some requests ...
+for domain, reason in client.suppressed_domains.items():
+    print(f"{domain}: {reason}")
+```
+
+### Disabling 403 suppression
+
+Pass `suppress_on_403=False` or use the CLI flag `--no-suppress-403`:
+
+```python
+from pypaperretriever import PaperRetriever
+
+retriever = PaperRetriever(
+    email="you@example.com",
+    doi="10.7759/cureus.76081",
+    suppress_on_403=False,
+)
+```
+
+```bash
+pypaperretriever \
+    --email you@example.com \
+    --doi 10.7759/cureus.76081 \
+    --no-suppress-403
+```
+
+---
+
 ## Using `HttpClient` directly
 
 You can instantiate `HttpClient` on its own for custom workflows:
@@ -148,6 +199,7 @@ else:
 | `user_agent` | `str` | `"PyPaperRetriever/1.0"` | Default `User-Agent` header and the name used for robots.txt look-ups. |
 | `respect_robots_txt` | `bool` | `False` | Enable robots.txt checking and Crawl-Delay enforcement. |
 | `honor_retry_after` | `bool` | `True` | Automatically retry on HTTP 429 responses. |
+| `suppress_on_403` | `bool` | `True` | Suppress domains that return 403 Forbidden. |
 | `max_retries` | `int` | `3` | Maximum number of 429 retries per request. |
 | `default_retry_after_s` | `float` | `60.0` | Fallback wait (seconds) when no rate-limit header is present. |
 | `max_retry_after_s` | `float` | `300.0` | Upper clamp on the server-requested wait time. |
@@ -165,6 +217,8 @@ else:
 - When `respect_robots_txt=False`, `get()` never returns `None`.
 - If 429 retry is enabled and the server keeps responding with 429 after
   `max_retries` attempts, the final 429 response is returned (not `None`).
+- If 403 suppression is enabled and the domain was previously blocked, a
+  synthetic `requests.Response` with status 403 is returned (not `None`).
 
 ---
 
@@ -174,13 +228,13 @@ else:
 
 | Class | How it's configured |
 |-------|---------------------|
-| `PaperRetriever` | Accepts `respect_robots_txt` constructor parameter; creates its own `HttpClient`. |
+| `PaperRetriever` | Accepts `respect_robots_txt` and `suppress_on_403` constructor parameters; creates its own `HttpClient`. |
 | `PubMedSearcher` | Accepts `respect_robots_txt`; creates its own `HttpClient` and passes the flag through to `PaperRetriever` and `ReferenceRetriever`. |
 | `ReferenceRetriever` | Accepts an optional `http_client` parameter. |
 | `utils.doi_to_pmid()` | Accepts an optional `http_client` parameter for its PMC ID Converter fallback request. |
 
-All classes benefit from 429 retry automatically (it is on by default in every
-`HttpClient` instance).
+All classes benefit from 429 retry and 403 suppression automatically (both are
+on by default in every `HttpClient` instance).
 
 ---
 
@@ -199,4 +253,5 @@ All classes benefit from 429 retry automatically (it is on by default in every
       members:
         - __init__
         - get
+        - suppressed_domains
       inherited_members: false

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -1,0 +1,127 @@
+# HTTP Client & robots.txt Support
+
+PyPaperRetriever includes an `HttpClient` that can optionally respect
+[robots.txt](https://en.wikipedia.org/wiki/Robots.txt) directives and
+per-domain **Crawl-Delay** values when fetching papers and metadata.
+
+By default this behaviour is **off** — `HttpClient` acts as a thin wrapper
+around `requests.get()` with zero delays. Opt in with `respect_robots_txt=True`
+when you want to be a polite crawler.
+
+## Quick example
+
+```python
+from pypaperretriever import PaperRetriever
+
+retriever = PaperRetriever(
+    email="you@example.com",
+    doi="10.7759/cureus.76081",
+    download_directory="PDFs",
+    respect_robots_txt=True,   # enable robots.txt + Crawl-Delay
+)
+retriever.download()
+```
+
+From the CLI:
+
+```bash
+pypaperretriever \
+    --email you@example.com \
+    --doi 10.7759/cureus.76081 \
+    --dwn-dir PDFs \
+    --respect-robots-txt
+```
+
+## How it works
+
+### robots.txt checking
+
+When `respect_robots_txt=True`, every outgoing GET request is first checked
+against the target domain's `robots.txt`.  If the URL is **disallowed** for the
+configured User-Agent, `HttpClient.get()` returns `None` and the caller skips
+that source.  If the `robots.txt` cannot be fetched (network error, 404, etc.)
+the domain is treated as fully permissive.
+
+Parsed `robots.txt` files are **cached per domain** for the lifetime of the
+`HttpClient` instance — repeat requests to the same domain do not re-fetch
+`robots.txt`.
+
+### Crawl-Delay
+
+If a domain's `robots.txt` specifies a `Crawl-Delay` for the active
+User-Agent, `HttpClient` sleeps between requests to that domain so consecutive
+fetches are at least `Crawl-Delay` seconds apart.  When no `Crawl-Delay` is
+declared, a random fallback between `rate_limit_min_s` and `rate_limit_max_s`
+(default 1–3 s) is used instead.
+
+Delays are tracked **per domain** — a slow Crawl-Delay on one site does not
+block requests to a different site.
+
+## Using `HttpClient` directly
+
+You can instantiate `HttpClient` on its own for custom workflows:
+
+```python
+from pypaperretriever import HttpClient
+
+client = HttpClient(
+    user_agent="MyBot/1.0",
+    respect_robots_txt=True,
+    rate_limit_min_s=1.0,
+    rate_limit_max_s=3.0,
+    verbosity=2,
+)
+
+response = client.get("https://api.example.com/data")
+if response is None:
+    print("Blocked by robots.txt")
+else:
+    print(response.status_code)
+```
+
+### Constructor parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `user_agent` | `str` | `"PyPaperRetriever/1.0"` | Default `User-Agent` header and the name used for robots.txt look-ups. |
+| `respect_robots_txt` | `bool` | `False` | Enable robots.txt checking and Crawl-Delay enforcement. |
+| `rate_limit_min_s` | `float` | `1.0` | Minimum fallback delay (seconds) when no Crawl-Delay is declared. |
+| `rate_limit_max_s` | `float` | `3.0` | Maximum fallback delay (seconds). |
+| `verbosity` | `int` | `1` | Logging verbosity: 0 = silent, 1 = warnings, 2 = info, 3 = debug. |
+
+### Return value of `get()`
+
+`HttpClient.get()` returns `Optional[requests.Response]`:
+
+- A normal `requests.Response` on success (any HTTP status code).
+- `None` **only** when `respect_robots_txt=True` and the URL is disallowed by
+  `robots.txt`. Callers must handle the `None` case.
+- When `respect_robots_txt=False`, `get()` never returns `None`.
+
+## Integration with other classes
+
+`HttpClient` is used internally by all main classes:
+
+| Class | How it's configured |
+|-------|---------------------|
+| `PaperRetriever` | Accepts `respect_robots_txt` constructor parameter; creates its own `HttpClient`. |
+| `PubMedSearcher` | Accepts `respect_robots_txt`; creates its own `HttpClient` and passes the flag through to `PaperRetriever` and `ReferenceRetriever`. |
+| `ReferenceRetriever` | Accepts an optional `http_client` parameter. |
+| `utils.doi_to_pmid()` | Accepts an optional `http_client` parameter for its PMC ID Converter fallback request. |
+
+## API Reference
+
+::: pypaperretriever.http_client.RobotsTxtCache
+    options:
+      members:
+        - __init__
+        - can_fetch
+        - crawl_delay
+      inherited_members: false
+
+::: pypaperretriever.http_client.HttpClient
+    options:
+      members:
+        - __init__
+        - get
+      inherited_members: false

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -1,14 +1,20 @@
-# HTTP Client & robots.txt Support
+# HTTP Client & Polite Crawling
 
-PyPaperRetriever includes an `HttpClient` that can optionally respect
-[robots.txt](https://en.wikipedia.org/wiki/Robots.txt) directives and
-per-domain **Crawl-Delay** values when fetching papers and metadata.
+PyPaperRetriever includes an `HttpClient` that wraps `requests.get()` with two
+opt-in politeness features:
 
-By default this behaviour is **off** — `HttpClient` acts as a thin wrapper
-around `requests.get()` with zero delays. Opt in with `respect_robots_txt=True`
-when you want to be a polite crawler.
+1. **robots.txt / Crawl-Delay** — check each domain's `robots.txt` before
+   fetching and respect its `Crawl-Delay` directive.
+2. **HTTP 429 retry** — automatically wait and retry when a server replies with
+   *429 Too Many Requests*.
 
-## Quick example
+By default robots.txt support is **off** (zero overhead) while 429 retry is
+**on** (safe default — it only activates when a server explicitly asks you to
+slow down).
+
+## Quick examples
+
+### Python
 
 ```python
 from pypaperretriever import PaperRetriever
@@ -22,7 +28,9 @@ retriever = PaperRetriever(
 retriever.download()
 ```
 
-From the CLI:
+429 retry is handled transparently — no code changes needed.
+
+### CLI
 
 ```bash
 pypaperretriever \
@@ -32,30 +40,78 @@ pypaperretriever \
     --respect-robots-txt
 ```
 
-## How it works
+---
 
-### robots.txt checking
+## robots.txt support
+
+### How it works
 
 When `respect_robots_txt=True`, every outgoing GET request is first checked
-against the target domain's `robots.txt`.  If the URL is **disallowed** for the
-configured User-Agent, `HttpClient.get()` returns `None` and the caller skips
-that source.  If the `robots.txt` cannot be fetched (network error, 404, etc.)
-the domain is treated as fully permissive.
+against the target domain's `robots.txt`.
 
-Parsed `robots.txt` files are **cached per domain** for the lifetime of the
-`HttpClient` instance — repeat requests to the same domain do not re-fetch
-`robots.txt`.
+- **Disallowed URL** — `HttpClient.get()` returns `None` and the caller skips
+  that source.
+- **Unreachable robots.txt** (network error, 404, etc.) — the domain is treated
+  as fully permissive.
+- **Caching** — parsed `robots.txt` files are cached per domain for the
+  lifetime of the `HttpClient` instance.  Repeat requests to the same domain do
+  not re-fetch `robots.txt`.
 
 ### Crawl-Delay
 
-If a domain's `robots.txt` specifies a `Crawl-Delay` for the active
-User-Agent, `HttpClient` sleeps between requests to that domain so consecutive
-fetches are at least `Crawl-Delay` seconds apart.  When no `Crawl-Delay` is
-declared, a random fallback between `rate_limit_min_s` and `rate_limit_max_s`
-(default 1–3 s) is used instead.
+If a domain's `robots.txt` declares a `Crawl-Delay` for the active User-Agent,
+`HttpClient` sleeps between requests to that domain so consecutive fetches are
+at least that many seconds apart.  When no `Crawl-Delay` is declared a random
+fallback between `rate_limit_min_s` and `rate_limit_max_s` (default 1–3 s) is
+used instead.
 
 Delays are tracked **per domain** — a slow Crawl-Delay on one site does not
 block requests to a different site.
+
+---
+
+## HTTP 429 (Too Many Requests) retry
+
+When `honor_retry_after=True` (the default) and a server responds with status
+**429**, `HttpClient` automatically determines how long to wait and retries the
+request — up to `max_retries` times (default 3).
+
+### Header priority
+
+The wait time is extracted from response headers in this order:
+
+| Priority | Header | Format |
+|----------|--------|--------|
+| 1 | `Retry-After` (RFC 7231) | Integer seconds **or** HTTP date |
+| 2 | `RateLimit-Reset` / `X-RateLimit-Reset` (IETF draft) | Unix timestamp (> 1 000 000 000) **or** seconds until reset |
+| 3 | *(none found)* | Falls back to `default_retry_after_s` (default 60 s) |
+
+The resolved wait time is clamped to `max_retry_after_s` (default 300 s) to
+prevent unbounded waits.
+
+### Example log output
+
+At `verbosity >= 1` you will see messages like:
+
+```text
+  [HttpClient] HTTP 429 — waiting 30s before retry (from Retry-After)
+```
+
+When no rate-limit headers are found and `verbosity >= 2`, all response headers
+are printed to help with debugging.
+
+### Disabling 429 retry
+
+Pass `honor_retry_after=False` to disable automatic retry entirely.  The 429
+response will be returned to the caller as-is.
+
+```python
+from pypaperretriever import HttpClient
+
+client = HttpClient(honor_retry_after=False)
+```
+
+---
 
 ## Using `HttpClient` directly
 
@@ -67,6 +123,10 @@ from pypaperretriever import HttpClient
 client = HttpClient(
     user_agent="MyBot/1.0",
     respect_robots_txt=True,
+    honor_retry_after=True,
+    max_retries=5,
+    default_retry_after_s=30.0,
+    max_retry_after_s=120.0,
     rate_limit_min_s=1.0,
     rate_limit_max_s=3.0,
     verbosity=2,
@@ -75,6 +135,8 @@ client = HttpClient(
 response = client.get("https://api.example.com/data")
 if response is None:
     print("Blocked by robots.txt")
+elif response.status_code == 429:
+    print("Still rate-limited after max retries")
 else:
     print(response.status_code)
 ```
@@ -85,6 +147,10 @@ else:
 |-----------|------|---------|-------------|
 | `user_agent` | `str` | `"PyPaperRetriever/1.0"` | Default `User-Agent` header and the name used for robots.txt look-ups. |
 | `respect_robots_txt` | `bool` | `False` | Enable robots.txt checking and Crawl-Delay enforcement. |
+| `honor_retry_after` | `bool` | `True` | Automatically retry on HTTP 429 responses. |
+| `max_retries` | `int` | `3` | Maximum number of 429 retries per request. |
+| `default_retry_after_s` | `float` | `60.0` | Fallback wait (seconds) when no rate-limit header is present. |
+| `max_retry_after_s` | `float` | `300.0` | Upper clamp on the server-requested wait time. |
 | `rate_limit_min_s` | `float` | `1.0` | Minimum fallback delay (seconds) when no Crawl-Delay is declared. |
 | `rate_limit_max_s` | `float` | `3.0` | Maximum fallback delay (seconds). |
 | `verbosity` | `int` | `1` | Logging verbosity: 0 = silent, 1 = warnings, 2 = info, 3 = debug. |
@@ -95,8 +161,12 @@ else:
 
 - A normal `requests.Response` on success (any HTTP status code).
 - `None` **only** when `respect_robots_txt=True` and the URL is disallowed by
-  `robots.txt`. Callers must handle the `None` case.
+  `robots.txt`.  Callers must handle the `None` case.
 - When `respect_robots_txt=False`, `get()` never returns `None`.
+- If 429 retry is enabled and the server keeps responding with 429 after
+  `max_retries` attempts, the final 429 response is returned (not `None`).
+
+---
 
 ## Integration with other classes
 
@@ -108,6 +178,11 @@ else:
 | `PubMedSearcher` | Accepts `respect_robots_txt`; creates its own `HttpClient` and passes the flag through to `PaperRetriever` and `ReferenceRetriever`. |
 | `ReferenceRetriever` | Accepts an optional `http_client` parameter. |
 | `utils.doi_to_pmid()` | Accepts an optional `http_client` parameter for its PMC ID Converter fallback request. |
+
+All classes benefit from 429 retry automatically (it is on by default in every
+`HttpClient` instance).
+
+---
 
 ## API Reference
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,7 +63,7 @@ nav:
       - PaperTracker: api/paper_tracker.md
       - Utils: api/utils.md
       - CLI: api/cli.md
-  - HTTP Client & robots.txt: http_client.md
+  - HTTP Client & Polite Crawling: http_client.md
   - FAQ: faq.md
 
 extra:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - PaperTracker: api/paper_tracker.md
       - Utils: api/utils.md
       - CLI: api/cli.md
+  - HTTP Client & robots.txt: http_client.md
   - FAQ: faq.md
 
 extra:

--- a/pypaperretriever/__init__.py
+++ b/pypaperretriever/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .http_client import HttpClient
 from .paper_retriever import PaperRetriever
 from .pubmed_searcher import PubMedSearcher
 from .reference_retriever import ReferenceRetriever
@@ -10,6 +11,7 @@ from .paper_tracker import PaperTracker
 from .utils import decode_doi, doi_to_pmid, encode_doi, pmid_to_doi
 
 __all__ = [
+    "HttpClient",
     "PaperRetriever",
     "PubMedSearcher",
     "ReferenceRetriever",

--- a/pypaperretriever/http_client.py
+++ b/pypaperretriever/http_client.py
@@ -1,10 +1,10 @@
-"""HTTP client with optional robots.txt, Crawl-Delay, and 429 retry support.
+"""HTTP client with robots.txt, Crawl-Delay, 429 retry, and 403 suppression.
 
 This module provides an :class:`HttpClient` that can optionally fetch and
 respect robots.txt directives, including Crawl-Delay, for every domain it
 contacts.  It can also automatically retry on HTTP 429 (Too Many Requests)
-responses using the delay indicated by the server.  When both features are
-disabled (the default) the client is a thin pass-through to
+responses and suppress domains that return HTTP 403 (Forbidden).  When all
+features are disabled the client is a thin pass-through to
 :func:`requests.get`.
 """
 
@@ -81,7 +81,7 @@ class RobotsTxtCache:
 
 
 class HttpClient:
-    """HTTP client with optional robots.txt, Crawl-Delay, and 429 retry support.
+    """HTTP client with robots.txt, 429 retry, and 403 suppression support.
 
     When *respect_robots_txt* is ``True`` the client:
 
@@ -97,13 +97,16 @@ class HttpClient:
     ``X-RateLimit-Reset`` (IETF draft) headers.  If none are present a
     *default_retry_after_s* fallback is used.
 
-    When both features are disabled (the default for robots.txt) the client is
-    a thin wrapper around :func:`requests.get` with no rate limiting.
+    When *suppress_on_403* is ``True`` (the default) the client records any
+    domain that returns HTTP 403 (Forbidden).  Subsequent requests to the same
+    domain are short-circuited with a synthetic 403 response, avoiding
+    redundant network round-trips during bulk downloads.
 
     Args:
         user_agent: Default User-Agent string.
         respect_robots_txt: Enable robots.txt checking and Crawl-Delay.
         honor_retry_after: Automatically retry on HTTP 429 responses.
+        suppress_on_403: Automatically suppress domains that return 403.
         max_retries: Maximum number of 429 retries per request.
         default_retry_after_s: Fallback wait time when no retry header is
             present.
@@ -118,6 +121,7 @@ class HttpClient:
         user_agent: str = "PyPaperRetriever/1.0",
         respect_robots_txt: bool = False,
         honor_retry_after: bool = True,
+        suppress_on_403: bool = True,
         max_retries: int = 3,
         default_retry_after_s: float = 60.0,
         max_retry_after_s: float = 300.0,
@@ -128,6 +132,7 @@ class HttpClient:
         self.user_agent = user_agent
         self.respect_robots_txt = respect_robots_txt
         self.honor_retry_after = honor_retry_after
+        self.suppress_on_403 = suppress_on_403
         self.max_retries = max_retries
         self.default_retry_after_s = default_retry_after_s
         self.max_retry_after_s = max_retry_after_s
@@ -135,6 +140,7 @@ class HttpClient:
         self.rate_limit_max_s = rate_limit_max_s
         self.verbosity = verbosity
         self._last_fetch_times: Dict[str, float] = {}
+        self._suppressed_domains: Dict[str, str] = {}
         self._robots_cache: Optional[RobotsTxtCache] = None
         if self.respect_robots_txt:
             self._robots_cache = RobotsTxtCache(user_agent=self.user_agent)
@@ -144,6 +150,46 @@ class HttpClient:
         """Return ``scheme://netloc`` for per-domain tracking."""
         parsed = urlparse(url)
         return f"{parsed.scheme}://{parsed.netloc}"
+
+    def _check_suppression(self, url: str) -> Optional[requests.Response]:
+        """Return a synthetic 403 if the domain of *url* is suppressed.
+
+        Args:
+            url: URL to check.
+
+        Returns:
+            A synthetic :class:`requests.Response` with status 403 if the
+            domain is suppressed, otherwise ``None``.
+        """
+        domain = self._domain_key(url)
+        if domain not in self._suppressed_domains:
+            return None
+        if self.verbosity >= 2:
+            reason = self._suppressed_domains[domain]
+            print(f"  [HttpClient] Skipping suppressed domain: {domain} ({reason})")
+        response = requests.Response()
+        response.status_code = 403
+        response.url = url
+        response._content = b""
+        return response
+
+    def _register_suppression(self, url: str) -> None:
+        """Record the domain of *url* as suppressed after a 403 response.
+
+        Args:
+            url: URL whose domain should be suppressed.
+        """
+        domain = self._domain_key(url)
+        if domain not in self._suppressed_domains:
+            reason = f"403 Forbidden at {time.strftime('%Y-%m-%d %H:%M:%S')}"
+            self._suppressed_domains[domain] = reason
+            if self.verbosity >= 1:
+                print(f"  [HttpClient] Domain suppressed due to 403 Forbidden: {domain}")
+
+    @property
+    def suppressed_domains(self) -> Dict[str, str]:
+        """Return a copy of the currently suppressed domains and reasons."""
+        return dict(self._suppressed_domains)
 
     def _apply_rate_limit(self, url: str) -> None:
         """Sleep to respect Crawl-Delay or fallback delay for this domain."""
@@ -267,8 +313,20 @@ class HttpClient:
 
         return wait_seconds
 
+    #: Domains that act as redirectors and should never be suppressed, because
+    #: a 403 from these domains originates at the *destination* site.
+    SUPPRESSION_EXEMPT_DOMAINS: set[str] = {
+        "doi.org",
+        "dx.doi.org",
+    }
+
+    def _is_suppression_exempt(self, url: str) -> bool:
+        """Return ``True`` if the domain of *url* must never be suppressed."""
+        netloc = urlparse(url).netloc.lower()
+        return netloc in self.SUPPRESSION_EXEMPT_DOMAINS
+
     def get(self, url: str, **kwargs: Any) -> Optional[requests.Response]:
-        """Make a GET request, optionally respecting robots.txt and 429 retry.
+        """Make a GET request with optional robots.txt, 429, and 403 handling.
 
         Args:
             url: The URL to fetch.
@@ -279,6 +337,13 @@ class HttpClient:
             A :class:`requests.Response`, or ``None`` if the URL is disallowed
             by robots.txt.
         """
+        # 1. Suppression check (before any network I/O)
+        if self.suppress_on_403:
+            suppressed = self._check_suppression(url)
+            if suppressed is not None:
+                return suppressed
+
+        # 2. robots.txt check
         if self.respect_robots_txt and self._robots_cache is not None:
             if not self._robots_cache.can_fetch(url):
                 if self.verbosity >= 1:
@@ -297,6 +362,7 @@ class HttpClient:
 
         response = requests.get(url, **kwargs)
 
+        # 3. 429 retry
         if self.honor_retry_after and response.status_code == 429:
             for attempt in range(self.max_retries):
                 wait = self._handle_429(response, url)
@@ -305,5 +371,13 @@ class HttpClient:
                 response = requests.get(url, **kwargs)
                 if response.status_code != 429:
                     break
+
+        # 4. 403 suppression registration
+        if (
+            self.suppress_on_403
+            and response.status_code == 403
+            and not self._is_suppression_exempt(url)
+        ):
+            self._register_suppression(url)
 
         return response

--- a/pypaperretriever/http_client.py
+++ b/pypaperretriever/http_client.py
@@ -1,15 +1,19 @@
-"""HTTP client with optional robots.txt and Crawl-Delay support.
+"""HTTP client with optional robots.txt, Crawl-Delay, and 429 retry support.
 
 This module provides an :class:`HttpClient` that can optionally fetch and
 respect robots.txt directives, including Crawl-Delay, for every domain it
-contacts.  When the feature is disabled (the default) the client is a thin
-pass-through to :func:`requests.get`.
+contacts.  It can also automatically retry on HTTP 429 (Too Many Requests)
+responses using the delay indicated by the server.  When both features are
+disabled (the default) the client is a thin pass-through to
+:func:`requests.get`.
 """
 
 from __future__ import annotations
 
 import random
 import time
+from datetime import datetime
+from email.utils import parsedate_to_datetime
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 from urllib.robotparser import RobotFileParser
@@ -77,7 +81,7 @@ class RobotsTxtCache:
 
 
 class HttpClient:
-    """HTTP client with optional robots.txt and Crawl-Delay support.
+    """HTTP client with optional robots.txt, Crawl-Delay, and 429 retry support.
 
     When *respect_robots_txt* is ``True`` the client:
 
@@ -87,12 +91,23 @@ class HttpClient:
        otherwise falls back to a random delay between *rate_limit_min_s* and
        *rate_limit_max_s*.
 
-    When *respect_robots_txt* is ``False`` (the default) the client is a thin
-    wrapper around :func:`requests.get` with no rate limiting.
+    When *honor_retry_after* is ``True`` the client automatically retries
+    requests that receive an HTTP 429 (Too Many Requests) response.  The wait
+    time is determined from ``Retry-After`` (RFC 7231), ``RateLimit-Reset`` or
+    ``X-RateLimit-Reset`` (IETF draft) headers.  If none are present a
+    *default_retry_after_s* fallback is used.
+
+    When both features are disabled (the default for robots.txt) the client is
+    a thin wrapper around :func:`requests.get` with no rate limiting.
 
     Args:
         user_agent: Default User-Agent string.
         respect_robots_txt: Enable robots.txt checking and Crawl-Delay.
+        honor_retry_after: Automatically retry on HTTP 429 responses.
+        max_retries: Maximum number of 429 retries per request.
+        default_retry_after_s: Fallback wait time when no retry header is
+            present.
+        max_retry_after_s: Cap on the wait time extracted from headers.
         rate_limit_min_s: Minimum fallback delay in seconds.
         rate_limit_max_s: Maximum fallback delay in seconds.
         verbosity: Logging verbosity (0=silent, 1=warnings, 2=info, 3=debug).
@@ -102,12 +117,20 @@ class HttpClient:
         self,
         user_agent: str = "PyPaperRetriever/1.0",
         respect_robots_txt: bool = False,
+        honor_retry_after: bool = True,
+        max_retries: int = 3,
+        default_retry_after_s: float = 60.0,
+        max_retry_after_s: float = 300.0,
         rate_limit_min_s: float = 1.0,
         rate_limit_max_s: float = 3.0,
         verbosity: int = 1,
     ) -> None:
         self.user_agent = user_agent
         self.respect_robots_txt = respect_robots_txt
+        self.honor_retry_after = honor_retry_after
+        self.max_retries = max_retries
+        self.default_retry_after_s = default_retry_after_s
+        self.max_retry_after_s = max_retry_after_s
         self.rate_limit_min_s = rate_limit_min_s
         self.rate_limit_max_s = rate_limit_max_s
         self.verbosity = verbosity
@@ -159,8 +182,93 @@ class HttpClient:
                 print(f"  [HttpClient] Sleeping {sleep_time:.2f}s for {domain}")
             time.sleep(sleep_time)
 
+    def _handle_429(self, response: requests.Response, url: str) -> float:
+        """Parse a 429 response to determine how long to wait before retrying.
+
+        The method checks, in order:
+
+        1. ``Retry-After`` header (RFC 7231) — integer seconds or HTTP date.
+        2. ``RateLimit-Reset`` / ``X-RateLimit-Reset`` (IETF draft) — Unix
+           timestamp (>1 000 000 000) or seconds-to-reset.
+        3. Falls back to *default_retry_after_s*.
+
+        The returned value is clamped to *max_retry_after_s*.
+
+        Args:
+            response: The 429 response.
+            url: The URL that was requested (for logging).
+
+        Returns:
+            Wait time in seconds.
+        """
+        wait_seconds: Optional[float] = None
+        header_used: Optional[str] = None
+
+        # 1. Retry-After (RFC 7231)
+        retry_after = response.headers.get("Retry-After")
+        if retry_after:
+            try:
+                wait_seconds = float(retry_after)
+                header_used = "Retry-After"
+            except ValueError:
+                try:
+                    retry_time = parsedate_to_datetime(retry_after)
+                    wait_seconds = (
+                        retry_time - datetime.now(retry_time.tzinfo)
+                    ).total_seconds()
+                    wait_seconds = max(0.0, wait_seconds)
+                    header_used = "Retry-After"
+                except (ValueError, TypeError):
+                    pass
+
+        # 2. RateLimit-Reset / X-RateLimit-Reset (IETF draft)
+        if wait_seconds is None:
+            reset_header = (
+                response.headers.get("RateLimit-Reset")
+                or response.headers.get("X-RateLimit-Reset")
+            )
+            if reset_header:
+                try:
+                    reset_value = int(reset_header)
+                    if reset_value > 1_000_000_000:
+                        wait_seconds = max(0.0, reset_value - time.time())
+                    else:
+                        wait_seconds = float(reset_value)
+                    header_used = (
+                        "RateLimit-Reset"
+                        if "RateLimit-Reset" in response.headers
+                        else "X-RateLimit-Reset"
+                    )
+                except (ValueError, TypeError):
+                    pass
+
+        # 3. Default fallback
+        if wait_seconds is None:
+            wait_seconds = self.default_retry_after_s
+            header_used = "default"
+            if self.verbosity >= 1:
+                print(
+                    "  [HttpClient] No rate-limit headers found, "
+                    f"using {self.default_retry_after_s}s default"
+                )
+                if self.verbosity >= 2:
+                    print("  All response headers:")
+                    for name, value in response.headers.items():
+                        print(f"    {name}: {value}")
+
+        # Clamp to max
+        wait_seconds = min(wait_seconds, self.max_retry_after_s)
+
+        if self.verbosity >= 1:
+            print(
+                f"  [HttpClient] HTTP 429 — waiting {wait_seconds:.0f}s "
+                f"before retry (from {header_used})"
+            )
+
+        return wait_seconds
+
     def get(self, url: str, **kwargs: Any) -> Optional[requests.Response]:
-        """Make a GET request, optionally respecting robots.txt.
+        """Make a GET request, optionally respecting robots.txt and 429 retry.
 
         Args:
             url: The URL to fetch.
@@ -187,4 +295,15 @@ class HttpClient:
         domain = self._domain_key(url)
         self._last_fetch_times[domain] = time.time()
 
-        return requests.get(url, **kwargs)
+        response = requests.get(url, **kwargs)
+
+        if self.honor_retry_after and response.status_code == 429:
+            for attempt in range(self.max_retries):
+                wait = self._handle_429(response, url)
+                time.sleep(wait)
+                self._last_fetch_times[domain] = time.time()
+                response = requests.get(url, **kwargs)
+                if response.status_code != 429:
+                    break
+
+        return response

--- a/pypaperretriever/http_client.py
+++ b/pypaperretriever/http_client.py
@@ -1,0 +1,190 @@
+"""HTTP client with optional robots.txt and Crawl-Delay support.
+
+This module provides an :class:`HttpClient` that can optionally fetch and
+respect robots.txt directives, including Crawl-Delay, for every domain it
+contacts.  When the feature is disabled (the default) the client is a thin
+pass-through to :func:`requests.get`.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+import requests
+
+
+class RobotsTxtCache:
+    """Lazily fetch and cache :class:`RobotFileParser` instances per domain.
+
+    Args:
+        user_agent: User-Agent string used for ``can_fetch`` / ``crawl_delay``
+            look-ups in the parsed robots.txt.
+    """
+
+    def __init__(self, user_agent: str) -> None:
+        self.user_agent = user_agent
+        self._cache: Dict[str, Optional[RobotFileParser]] = {}
+
+    @staticmethod
+    def _domain_key(url: str) -> str:
+        """Return ``scheme://netloc`` for *url*."""
+        parsed = urlparse(url)
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+    def get_parser(self, url: str) -> Optional[RobotFileParser]:
+        """Return a :class:`RobotFileParser` for the domain of *url*.
+
+        The parser is fetched and cached on first access.  Returns ``None``
+        when the robots.txt cannot be retrieved (treated as fully permissive).
+        """
+        key = self._domain_key(url)
+        if key not in self._cache:
+            self._cache[key] = self._fetch_robots_txt(key)
+        return self._cache[key]
+
+    @staticmethod
+    def _fetch_robots_txt(domain_key: str) -> Optional[RobotFileParser]:
+        """Fetch and parse robots.txt for *domain_key*."""
+        robots_url = f"{domain_key}/robots.txt"
+        rp = RobotFileParser()
+        rp.set_url(robots_url)
+        try:
+            rp.read()
+            return rp
+        except Exception:
+            return None
+
+    def can_fetch(self, url: str) -> bool:
+        """Check whether the user-agent is allowed to fetch *url*."""
+        parser = self.get_parser(url)
+        if parser is None:
+            return True
+        return parser.can_fetch(self.user_agent, url)
+
+    def crawl_delay(self, url: str) -> Optional[float]:
+        """Return the Crawl-Delay for the domain of *url*, or ``None``."""
+        parser = self.get_parser(url)
+        if parser is None:
+            return None
+        delay = parser.crawl_delay(self.user_agent)
+        if delay is not None:
+            return float(delay)
+        return None
+
+
+class HttpClient:
+    """HTTP client with optional robots.txt and Crawl-Delay support.
+
+    When *respect_robots_txt* is ``True`` the client:
+
+    1. Checks ``can_fetch()`` before each request and returns ``None`` for
+       disallowed URLs.
+    2. Applies the Crawl-Delay directive for the target domain if present,
+       otherwise falls back to a random delay between *rate_limit_min_s* and
+       *rate_limit_max_s*.
+
+    When *respect_robots_txt* is ``False`` (the default) the client is a thin
+    wrapper around :func:`requests.get` with no rate limiting.
+
+    Args:
+        user_agent: Default User-Agent string.
+        respect_robots_txt: Enable robots.txt checking and Crawl-Delay.
+        rate_limit_min_s: Minimum fallback delay in seconds.
+        rate_limit_max_s: Maximum fallback delay in seconds.
+        verbosity: Logging verbosity (0=silent, 1=warnings, 2=info, 3=debug).
+    """
+
+    def __init__(
+        self,
+        user_agent: str = "PyPaperRetriever/1.0",
+        respect_robots_txt: bool = False,
+        rate_limit_min_s: float = 1.0,
+        rate_limit_max_s: float = 3.0,
+        verbosity: int = 1,
+    ) -> None:
+        self.user_agent = user_agent
+        self.respect_robots_txt = respect_robots_txt
+        self.rate_limit_min_s = rate_limit_min_s
+        self.rate_limit_max_s = rate_limit_max_s
+        self.verbosity = verbosity
+        self._last_fetch_times: Dict[str, float] = {}
+        self._robots_cache: Optional[RobotsTxtCache] = None
+        if self.respect_robots_txt:
+            self._robots_cache = RobotsTxtCache(user_agent=self.user_agent)
+
+    @staticmethod
+    def _domain_key(url: str) -> str:
+        """Return ``scheme://netloc`` for per-domain tracking."""
+        parsed = urlparse(url)
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+    def _apply_rate_limit(self, url: str) -> None:
+        """Sleep to respect Crawl-Delay or fallback delay for this domain."""
+        if not self.respect_robots_txt:
+            return
+
+        domain = self._domain_key(url)
+        last_time = self._last_fetch_times.get(domain)
+        if last_time is None:
+            return
+
+        delay_seconds: Optional[float] = None
+
+        if self._robots_cache is not None:
+            delay_seconds = self._robots_cache.crawl_delay(url)
+            if delay_seconds is not None and self.verbosity >= 3:
+                print(
+                    f"  [HttpClient] Crawl-Delay for {domain}: "
+                    f"{delay_seconds}s"
+                )
+
+        if delay_seconds is None:
+            delay_seconds = random.uniform(
+                self.rate_limit_min_s, self.rate_limit_max_s
+            )
+            if self.verbosity >= 3:
+                print(
+                    f"  [HttpClient] Fallback delay for {domain}: "
+                    f"{delay_seconds:.2f}s"
+                )
+
+        elapsed = time.time() - last_time
+        sleep_time = delay_seconds - elapsed
+        if sleep_time > 0:
+            if self.verbosity >= 3:
+                print(f"  [HttpClient] Sleeping {sleep_time:.2f}s for {domain}")
+            time.sleep(sleep_time)
+
+    def get(self, url: str, **kwargs: Any) -> Optional[requests.Response]:
+        """Make a GET request, optionally respecting robots.txt.
+
+        Args:
+            url: The URL to fetch.
+            **kwargs: Additional keyword arguments passed to
+                :func:`requests.get`.
+
+        Returns:
+            A :class:`requests.Response`, or ``None`` if the URL is disallowed
+            by robots.txt.
+        """
+        if self.respect_robots_txt and self._robots_cache is not None:
+            if not self._robots_cache.can_fetch(url):
+                if self.verbosity >= 1:
+                    print(f"  [HttpClient] Blocked by robots.txt: {url}")
+                return None
+
+        self._apply_rate_limit(url)
+
+        headers = kwargs.get("headers", {})
+        if "User-Agent" not in headers:
+            headers["User-Agent"] = self.user_agent
+            kwargs["headers"] = headers
+
+        domain = self._domain_key(url)
+        self._last_fetch_times[domain] = time.time()
+
+        return requests.get(url, **kwargs)

--- a/pypaperretriever/paper_retriever.py
+++ b/pypaperretriever/paper_retriever.py
@@ -550,3 +550,7 @@ def main() -> None:
 
     retriever.download()
 
+
+if __name__ == '__main__':
+    main()
+

--- a/pypaperretriever/paper_retriever.py
+++ b/pypaperretriever/paper_retriever.py
@@ -36,6 +36,9 @@ class PaperRetriever:
         override_previous_attempt (bool, optional): Overwrite existing downloads.
         respect_robots_txt (bool, optional): Respect robots.txt directives and
             Crawl-Delay for all HTTP requests.
+        suppress_on_403 (bool, optional): Suppress domains that return 403
+            Forbidden, returning a cached 403 for subsequent requests to the
+            same domain.
 
     Attributes:
         doi (str): DOI encoded for safe file paths.
@@ -47,7 +50,7 @@ class PaperRetriever:
         on_scihub (bool): ``True`` if the PDF was found on Sci-Hub.
     """
 
-    def __init__(self, email, doi=None, pmid=None, allow_scihub=False, download_directory='PDFs', filename=None, override_previous_attempt=False, respect_robots_txt=False):
+    def __init__(self, email, doi=None, pmid=None, allow_scihub=False, download_directory='PDFs', filename=None, override_previous_attempt=False, respect_robots_txt=False, suppress_on_403=True):
         self.email = email
         if not doi and not pmid:
             raise ValueError("Either a DOI or PMID must be provided")
@@ -65,6 +68,7 @@ class PaperRetriever:
         self.download_directory = download_directory
         self.filename = filename
         self.respect_robots_txt = respect_robots_txt
+        self.suppress_on_403 = suppress_on_403
         self.user_agents = [
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15",
@@ -74,6 +78,7 @@ class PaperRetriever:
         self._http_client = HttpClient(
             user_agent=random.choice(self.user_agents),
             respect_robots_txt=respect_robots_txt,
+            suppress_on_403=suppress_on_403,
         )
  
     def download(self) -> Self:
@@ -533,9 +538,11 @@ def main() -> None:
                     help='Allow downloading from Sci-Hub if available (true/false).')
     parser.add_argument('--respect-robots-txt', action='store_true', default=False,
                     help='Respect robots.txt directives and Crawl-Delay for all domains.')
+    parser.add_argument('--no-suppress-403', action='store_true', default=False,
+                    help='Disable automatic suppression of domains that return 403 Forbidden.')
 
     args = parser.parse_args()
-    args.allow_scihub = args.allow_scihub.lower() == 'true' 
+    args.allow_scihub = args.allow_scihub.lower() == 'true'
 
     retriever = PaperRetriever(
         email=args.email,
@@ -546,6 +553,7 @@ def main() -> None:
         override_previous_attempt=args.override,
         allow_scihub=args.allow_scihub,
         respect_robots_txt=args.respect_robots_txt,
+        suppress_on_403=not args.no_suppress_403,
     )
 
     retriever.download()

--- a/pypaperretriever/paper_retriever.py
+++ b/pypaperretriever/paper_retriever.py
@@ -16,6 +16,7 @@ import requests
 from bs4 import BeautifulSoup
 from typing import Self
 
+from .http_client import HttpClient
 from .utils import decode_doi, doi_to_pmid, encode_doi, entrez_efetch, pmid_to_doi
 
 
@@ -33,6 +34,8 @@ class PaperRetriever:
         download_directory (str, optional): Directory where PDFs are stored.
         filename (str, optional): Custom filename for the downloaded PDF.
         override_previous_attempt (bool, optional): Overwrite existing downloads.
+        respect_robots_txt (bool, optional): Respect robots.txt directives and
+            Crawl-Delay for all HTTP requests.
 
     Attributes:
         doi (str): DOI encoded for safe file paths.
@@ -44,7 +47,7 @@ class PaperRetriever:
         on_scihub (bool): ``True`` if the PDF was found on Sci-Hub.
     """
 
-    def __init__(self, email, doi=None, pmid=None, allow_scihub=False, download_directory='PDFs', filename=None, override_previous_attempt=False):
+    def __init__(self, email, doi=None, pmid=None, allow_scihub=False, download_directory='PDFs', filename=None, override_previous_attempt=False, respect_robots_txt=False):
         self.email = email
         if not doi and not pmid:
             raise ValueError("Either a DOI or PMID must be provided")
@@ -61,12 +64,17 @@ class PaperRetriever:
         self.override_previous_attempt = override_previous_attempt
         self.download_directory = download_directory
         self.filename = filename
+        self.respect_robots_txt = respect_robots_txt
         self.user_agents = [
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15",
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:88.0) Gecko/20100101 Firefox/88.0",
             "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Mobile Safari/537.36",
         ]
+        self._http_client = HttpClient(
+            user_agent=random.choice(self.user_agents),
+            respect_robots_txt=respect_robots_txt,
+        )
  
     def download(self) -> Self:
         """Find and download the paper.
@@ -119,8 +127,10 @@ class PaperRetriever:
         """
 
         url = f"https://api.unpaywall.org/v2/{decode_doi(self.doi)}?email={self.email}"
-        response = requests.get(url)
-        
+        response = self._http_client.get(url)
+        if response is None:
+            return self
+
         if response.status_code == 200:
             data = response.json()
             pdf_urls = [None, None, None, None]
@@ -169,7 +179,9 @@ class PaperRetriever:
 
             article_link = f'https://pmc.ncbi.nlm.nih.gov/articles/{pmc_id}/'
 
-            response = requests.get(article_link, headers={"User-Agent": random.choice(self.user_agents)})
+            response = self._http_client.get(article_link, headers={"User-Agent": random.choice(self.user_agents)})
+            if response is None:
+                return self
 
             if response.status_code == 200:
                 soup = BeautifulSoup(response.content, 'html.parser')
@@ -200,7 +212,9 @@ class PaperRetriever:
         pdf_urls = []
         
         try:
-            response = requests.get(full_url)
+            response = self._http_client.get(full_url)
+            if response is None:
+                return self
             if response.status_code == 200:
                 data = response.json()
                 primary_url = data.get('message', {}).get('URL', None)
@@ -211,12 +225,14 @@ class PaperRetriever:
             
             for url in urls:
                 try:
-                    response = requests.get(url, headers={
+                    response = self._http_client.get(url, headers={
                         "User-Agent":  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
                                     "AppleWebKit/537.36 (KHTML, like Gecko) " +
                                     "Chrome/58.0.3029.110 Safari/537.3"
                     }, timeout=10)  # Added timeout for better error handling
-                    
+                    if response is None:
+                        continue
+
                     if response.status_code == 200:
                         final_url = response.url  # The final resolved URL after redirects
                         soup = BeautifulSoup(response.content, 'html.parser')
@@ -293,7 +309,8 @@ class PaperRetriever:
         urls = [f"{mirror}/{decode_doi(self.doi)}" for mirror in mirror_list]
 
         for i, url in enumerate(urls):
-            time.sleep(random.randint(1, 3)) # Delay between requests, avoids being blocked
+            if not self.respect_robots_txt:
+                time.sleep(random.randint(1, 3)) # Delay between requests, avoids being blocked
             headers = {
                 "User-Agent": random.choice(self.user_agents),
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
@@ -301,7 +318,9 @@ class PaperRetriever:
                 "Referer": "https://www.google.com/",
             }
             try:
-                r = requests.get(url, headers=headers)
+                r = self._http_client.get(url, headers=headers)
+                if r is None:
+                    continue
                 if r.status_code == 200:
                     if len(r.text) < 1:
                         print("""We probably got blocked by Sci-Hub for too many requests. 
@@ -345,7 +364,9 @@ class PaperRetriever:
 
         for pdf_url in self.pdf_urls:
             try:
-                response = requests.get(pdf_url, headers=headers, stream=True)
+                response = self._http_client.get(pdf_url, headers=headers, stream=True)
+                if response is None:
+                    continue
                 if response.status_code == 200:
                     with open(pdf_path, 'wb') as f:
                         for chunk in response.iter_content(chunk_size=8192):
@@ -510,6 +531,8 @@ def main() -> None:
     parser.add_argument('--override', action='store_true', help='Override previous download attempts.')
     parser.add_argument('--allow-scihub', choices=['true', 'false'], default='false',
                     help='Allow downloading from Sci-Hub if available (true/false).')
+    parser.add_argument('--respect-robots-txt', action='store_true', default=False,
+                    help='Respect robots.txt directives and Crawl-Delay for all domains.')
 
     args = parser.parse_args()
     args.allow_scihub = args.allow_scihub.lower() == 'true' 
@@ -522,6 +545,7 @@ def main() -> None:
         filename=args.filename,
         override_previous_attempt=args.override,
         allow_scihub=args.allow_scihub,
+        respect_robots_txt=args.respect_robots_txt,
     )
 
     retriever.download()

--- a/pypaperretriever/paper_retriever.py
+++ b/pypaperretriever/paper_retriever.py
@@ -164,7 +164,7 @@ class PaperRetriever:
 
         """
         pmc_id = None
-        id = self.pmid if self.pmid else doi_to_pmid(decode_doi(self.doi), self.email)
+        id = self.pmid if self.pmid else doi_to_pmid(decode_doi(self.doi), self.email, http_client=self._http_client)
         records = entrez_efetch(self.email, id)
         try:
             id_list = records['PubmedArticle'][0]['PubmedData']['ArticleIdList']

--- a/pypaperretriever/pubmed_searcher.py
+++ b/pypaperretriever/pubmed_searcher.py
@@ -11,6 +11,7 @@ from Bio import Entrez
 from tqdm import tqdm
 from typing import Self
 
+from .http_client import HttpClient
 from .image_extractor import ImageExtractor
 from .paper_retriever import PaperRetriever
 from .reference_retriever import ReferenceRetriever
@@ -32,13 +33,14 @@ class PubMedSearcher:
         email (str): Email address used for API calls.
     """
 
-    def __init__(self, search_string=None, df=None, email=""):
+    def __init__(self, search_string=None, df=None, email="", respect_robots_txt=False):
         """Initialize the searcher.
 
         Args:
             search_string (str | None): Query to submit to PubMed.
             df (pandas.DataFrame | None): Existing table of articles.
             email (str): Email address required by Entrez.
+            respect_robots_txt (bool): Respect robots.txt directives and Crawl-Delay.
         """
         self.search_string = search_string
         self.df = df if df is not None else pd.DataFrame()
@@ -51,6 +53,8 @@ class PubMedSearcher:
         else:
             print("Please provide an email address to use for querying PubMed.")
             raise ValueError("Email address is required for PubMed queries.")
+        self.respect_robots_txt = respect_robots_txt
+        self._http_client = HttpClient(respect_robots_txt=respect_robots_txt)
 
     def search(
         self,
@@ -159,7 +163,8 @@ class PubMedSearcher:
                                         doi=doi,
                                         email=self.email,
                                         allow_scihub=allow_scihub,
-                                        download_directory=download_directory
+                                        download_directory=download_directory,
+                                        respect_robots_txt=self.respect_robots_txt,
                                     ).download().filepath
             if pdf_filepath in [None, '', 'unavailable']:
                 self.df.at[index, 'download_complete'] = 'unavailable'
@@ -254,7 +259,7 @@ class PubMedSearcher:
                 continue
             
             # Initialize ReferenceRetriever with available identifiers
-            retriever = ReferenceRetriever(email=self.email, doi=row.get('doi'), pmid=row.get('pmid'), standardize=True)
+            retriever = ReferenceRetriever(email=self.email, doi=row.get('doi'), pmid=row.get('pmid'), standardize=True, http_client=self._http_client)
             references = retriever.fetch_references()
             
             # Store references or mark as "Not found" if empty
@@ -284,7 +289,7 @@ class PubMedSearcher:
                 continue
             
             # Initialize ReferenceRetriever with available identifiers
-            retriever = ReferenceRetriever(email=self.email, doi=row.get('doi'), pmid=row.get('pmid'))
+            retriever = ReferenceRetriever(email=self.email, doi=row.get('doi'), pmid=row.get('pmid'), http_client=self._http_client)
             cited_by = retriever.fetch_cited_by()  # Now uses both Europe PMC & PubMed
             
             # Store citing articles or mark as "Not found" if empty
@@ -444,17 +449,19 @@ class PubMedSearcher:
         print(url)
 
         try:
-            response = requests.get(url)
+            response = self._http_client.get(url)
+            if response is None:
+                return None
             if response.status_code == 200:
                 xml_content = response.text
                 os.makedirs(download_directory, exist_ok=True)
                 # Use filename_suffix if provided, else default to PMID
                 filename = f"{filename_suffix}.xml" if filename_suffix else f"{pmid}.xml"
                 file_path = os.path.join(download_directory, filename)
-                
+
                 with open(file_path, 'w', encoding='utf-8') as file:
                     file.write(xml_content)
-                
+
                 print(f"Article XML downloaded successfully to {file_path}.")
                 return file_path
             else:
@@ -563,7 +570,9 @@ class PubMedSearcher:
             "identifier": "oai:pubmedcentral.nih.gov:" + pmcid,
             "metadataPrefix": "pmc"
         }
-        response = requests.get(base_url, params=params)
+        response = self._http_client.get(base_url, params=params)
+        if response is None:
+            return None
 
         if response.status_code == 200:
             if 'is not supported by the item or by the repository.' in response.content.decode():

--- a/pypaperretriever/reference_retriever.py
+++ b/pypaperretriever/reference_retriever.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import requests
 from Bio import Entrez
 
 from .utils import doi_to_pmid
+
+if TYPE_CHECKING:
+    from .http_client import HttpClient
 
 
 class ReferenceRetriever:
@@ -19,14 +22,16 @@ class ReferenceRetriever:
         doi (str | None): Digital Object Identifier.
         pmid (str | None): PubMed identifier.
         standardize (bool): If ``True`` the output dictionaries share common keys.
+        http_client (HttpClient | None): Optional HTTP client for rate-limited requests.
     """
-    
+
     def __init__(
         self,
         email: str,
         doi: Optional[str] = None,
         pmid: Optional[str] = None,
         standardize: bool = True,
+        http_client: Optional[HttpClient] = None,
     ):
         """
         Initialize the retriever with either DOI or PMID.
@@ -35,18 +40,26 @@ class ReferenceRetriever:
             email (str): Email for API access
             doi (str, optional): Digital Object Identifier
             pmid (str, optional): PubMed ID
+            http_client (HttpClient, optional): HTTP client for rate-limited requests
         """
         self.email = email
         self.doi = doi
         self.pmid = pmid
         self.standardize = standardize
+        self._http_client = http_client
 
         print(f"[ReferenceRetriever] Initializing with DOI: {doi} and PMID: {pmid}")
 
         if self.doi and not self.pmid:
             print(f"[ReferenceRetriever] Converting DOI to PMID for DOI: {self.doi}")
-            self.pmid = doi_to_pmid(self.doi, self.email)
+            self.pmid = doi_to_pmid(self.doi, self.email, http_client=self._http_client)
             print(f"[ReferenceRetriever] Converted DOI {self.doi} to PMID: {self.pmid}")
+
+    def _do_get(self, url: str, **kwargs) -> requests.Response | None:
+        """Make a GET request, using the HTTP client if available."""
+        if self._http_client is not None:
+            return self._http_client.get(url, **kwargs)
+        return requests.get(url, **kwargs)
 
     def fetch_references(self) -> List[Dict[str, Any]]:
         """Fetch references for the current paper.
@@ -81,7 +94,7 @@ class ReferenceRetriever:
         if not self.pmid:
             if self.doi:
                 print(f"[ReferenceRetriever] Converting DOI to PMID for DOI: {self.doi}")
-                self.pmid = doi_to_pmid(self.doi, self.email)
+                self.pmid = doi_to_pmid(self.doi, self.email, http_client=self._http_client)
                 print(f"[ReferenceRetriever] Converted DOI {self.doi} to PMID: {self.pmid}")
                 if not self.pmid:
                     raise ValueError("Unable to convert DOI to PMID.")
@@ -112,7 +125,7 @@ class ReferenceRetriever:
                 print(f"[ReferenceRetriever] No metadata found for PMID: {self.pmid}")
         elif self.doi:
             print(f"[ReferenceRetriever] Fetching metadata using DOI: {self.doi}")
-            pmid = doi_to_pmid(self.doi, self.email)
+            pmid = doi_to_pmid(self.doi, self.email, http_client=self._http_client)
             if pmid:
                 print(f"[ReferenceRetriever] Converted DOI {self.doi} to PMID: {pmid}")
                 articles = self._fetch_articles_details([pmid])
@@ -185,7 +198,9 @@ class ReferenceRetriever:
         url = f"https://www.ebi.ac.uk/europepmc/webservices/rest/MED/{pmid}/references?page=1&pageSize=1000&format=json"
         print(f"[ReferenceRetriever] Requesting Europe PMC references from URL: {url}")
         try:
-            response = requests.get(url)
+            response = self._do_get(url)
+            if response is None:
+                return []
             if response.status_code == 200:
                 data = response.json()
                 references = data.get('referenceList', {}).get('reference', [])
@@ -240,7 +255,9 @@ class ReferenceRetriever:
         url = f"https://api.crossref.org/works/{doi}"
         print(f"[ReferenceRetriever] Requesting CrossRef references from URL: {url}")
         try:
-            response = requests.get(url)
+            response = self._do_get(url)
+            if response is None:
+                return []
             if response.status_code == 200:
                 data = response.json()
                 references = data['message'].get('reference', [])
@@ -265,7 +282,9 @@ class ReferenceRetriever:
         url = f"https://www.ebi.ac.uk/europepmc/webservices/rest/MED/{pmid}/citations?format=json"
         print(f"[ReferenceRetriever] Requesting Europe PMC citing articles from URL: {url}")
         try:
-            response = requests.get(url)
+            response = self._do_get(url)
+            if response is None:
+                return []
             if response.status_code == 200:
                 data = response.json()
                 citations = data.get('citationList', {}).get('citation', [])

--- a/pypaperretriever/utils.py
+++ b/pypaperretriever/utils.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import quote, unquote
 
 from Bio import Entrez
 import requests
+
+if TYPE_CHECKING:
+    from .http_client import HttpClient
 
 
 def entrez_efetch(email: str, id: str) -> Any:
@@ -49,7 +52,7 @@ def pmid_to_doi(pmid: str, email: str) -> str | None:
     return None
 
 
-def doi_to_pmid(doi: str, email: str) -> str | None:
+def doi_to_pmid(doi: str, email: str, http_client: Optional[HttpClient] = None) -> str | None:
     """Convert a DOI to a PMID.
 
     The function first queries the Entrez API. If that fails, the PMC ID
@@ -58,6 +61,7 @@ def doi_to_pmid(doi: str, email: str) -> str | None:
     Args:
         doi (str): Digital Object Identifier to convert.
         email (str): Email address required by the Entrez API.
+        http_client (HttpClient | None): Optional HTTP client for rate-limited requests.
 
     Returns:
         str | None: PMID if found, otherwise ``None``.
@@ -76,7 +80,12 @@ def doi_to_pmid(doi: str, email: str) -> str | None:
     try:
         url_base = "https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/?"
         url = f"{url_base}ids={doi}&format=json"
-        response = requests.get(url)
+        if http_client is not None:
+            response = http_client.get(url)
+            if response is None:
+                return None
+        else:
+            response = requests.get(url)
         if response.status_code == 200:
             data = response.json()
             pmid = data.get("records", [{}])[0].get("pmid", None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-pandas==2.2.3
-setuptools==75.8.0
-numpy==1.26
-tqdm==4.64.1
-biopython==1.83
-lxml==5.2.0
-requests==2.31.0
-PyMuPDF==1.24.1
-pdf2image==1.17.0
-pytest==8.3.4
-beautifulsoup4==4.12.3
-opencv-python==4.11.0.86
+pandas>=2.2.3, <3.0
+setuptools>=75.8.0, <76.0
+numpy>=1.26, <2.0
+tqdm>=4.64.1. <5.0
+biopython>=1.83, <2.0
+lxml>=5.2.0, <6.0
+requests>=2.31.0, <3.0
+PyMuPDF>=1.24.1, <2.0
+pdf2image>=1.17.0. <2.0
+pytest>=8.3.4, <9.0
+beautifulsoup4>=4.12.3, <5.0
+opencv-python>=4.11.0.86, <5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 pandas>=2.2.3, <3.0
 setuptools>=75.8.0, <76.0
-numpy>=1.26, <2.0
-tqdm>=4.64.1. <5.0
+numpy>=1.26, <3.0
+tqdm>=4.64.1, <5.0
 biopython>=1.83, <2.0
 lxml>=5.2.0, <6.0
 requests>=2.31.0, <3.0
 PyMuPDF>=1.24.1, <2.0
-pdf2image>=1.17.0. <2.0
+pdf2image>=1.17.0, <2.0
 pytest>=8.3.4, <9.0
 beautifulsoup4>=4.12.3, <5.0
 opencv-python>=4.11.0.86, <5.0

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -442,3 +442,132 @@ class TestHttpClient429Retry:
         assert resp.status_code == 200
         assert mock_get.call_count == 3
         assert mock_sleep.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# HttpClient tests — 403 domain suppression
+# ---------------------------------------------------------------------------
+
+class TestHttpClient403Suppression:
+    """Tests for the 403 domain suppression feature."""
+
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_403_suppresses_domain(self, mock_get, _mock_time):
+        resp_403 = Mock(status_code=403, headers={})
+        resp_403.url = "https://publisher.com/article/1"
+        mock_get.return_value = resp_403
+
+        client = HttpClient(suppress_on_403=True, verbosity=0)
+        resp1 = client.get("https://publisher.com/article/1")
+
+        assert resp1.status_code == 403
+        assert mock_get.call_count == 1
+
+        # Second request to the same domain should be short-circuited
+        resp2 = client.get("https://publisher.com/article/2")
+
+        assert resp2.status_code == 403
+        assert resp2.url == "https://publisher.com/article/2"
+        # Still only 1 real network call
+        assert mock_get.call_count == 1
+
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_403_does_not_suppress_different_domain(self, mock_get, _mock_time):
+        resp_403 = Mock(status_code=403, headers={})
+        resp_403.url = "https://publisher-a.com/page"
+        resp_200 = Mock(status_code=200, headers={})
+        mock_get.side_effect = [resp_403, resp_200]
+
+        client = HttpClient(suppress_on_403=True, verbosity=0)
+        client.get("https://publisher-a.com/page")
+        resp2 = client.get("https://publisher-b.com/page")
+
+        assert resp2.status_code == 200
+        assert mock_get.call_count == 2
+
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_suppression_disabled(self, mock_get, _mock_time):
+        resp_403 = Mock(status_code=403, headers={})
+        resp_403.url = "https://publisher.com/article/1"
+        mock_get.return_value = resp_403
+
+        client = HttpClient(suppress_on_403=False, verbosity=0)
+        client.get("https://publisher.com/article/1")
+        client.get("https://publisher.com/article/2")
+
+        # Both requests should hit the network
+        assert mock_get.call_count == 2
+
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_doi_org_not_suppressed(self, mock_get, _mock_time):
+        resp_403 = Mock(status_code=403, headers={})
+        resp_403.url = "https://doi.org/10.1234/test"
+        mock_get.return_value = resp_403
+
+        client = HttpClient(suppress_on_403=True, verbosity=0)
+        client.get("https://doi.org/10.1234/test")
+        client.get("https://doi.org/10.5678/other")
+
+        # doi.org is exempt — both requests should hit the network
+        assert mock_get.call_count == 2
+        assert client.suppressed_domains == {}
+
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_dx_doi_org_not_suppressed(self, mock_get, _mock_time):
+        resp_403 = Mock(status_code=403, headers={})
+        resp_403.url = "https://dx.doi.org/10.1234/test"
+        mock_get.return_value = resp_403
+
+        client = HttpClient(suppress_on_403=True, verbosity=0)
+        client.get("https://dx.doi.org/10.1234/test")
+        client.get("https://dx.doi.org/10.5678/other")
+
+        assert mock_get.call_count == 2
+        assert client.suppressed_domains == {}
+
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_200_does_not_suppress(self, mock_get, _mock_time):
+        resp_200 = Mock(status_code=200, headers={})
+        mock_get.return_value = resp_200
+
+        client = HttpClient(suppress_on_403=True, verbosity=0)
+        client.get("https://publisher.com/article/1")
+        client.get("https://publisher.com/article/2")
+
+        assert mock_get.call_count == 2
+        assert client.suppressed_domains == {}
+
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_suppressed_domains_property(self, mock_get, _mock_time):
+        resp_403 = Mock(status_code=403, headers={})
+        resp_403.url = "https://blocked.com/x"
+        mock_get.return_value = resp_403
+
+        client = HttpClient(suppress_on_403=True, verbosity=0)
+        client.get("https://blocked.com/x")
+
+        domains = client.suppressed_domains
+        assert "https://blocked.com" in domains
+        assert "403 Forbidden" in domains["https://blocked.com"]
+
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_synthetic_403_has_correct_url(self, mock_get, _mock_time):
+        resp_403 = Mock(status_code=403, headers={})
+        resp_403.url = "https://publisher.com/article/1"
+        mock_get.return_value = resp_403
+
+        client = HttpClient(suppress_on_403=True, verbosity=0)
+        client.get("https://publisher.com/article/1")
+
+        # Synthetic response should carry the new URL
+        resp2 = client.get("https://publisher.com/article/99")
+        assert resp2.status_code == 403
+        assert resp2.url == "https://publisher.com/article/99"

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,4 +1,5 @@
-from unittest.mock import Mock, patch, MagicMock
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch, MagicMock, call
 from urllib.robotparser import RobotFileParser
 
 import pytest
@@ -276,3 +277,168 @@ class TestHttpClientWithRobots:
         client.get("https://example.com/page2")
 
         mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# HttpClient tests — _handle_429 header parsing
+# ---------------------------------------------------------------------------
+
+class TestHandle429:
+    """Tests for _handle_429 header parsing logic."""
+
+    def _make_client(self, **kwargs):
+        return HttpClient(
+            honor_retry_after=True,
+            verbosity=0,
+            **kwargs,
+        )
+
+    def test_retry_after_integer_seconds(self):
+        client = self._make_client()
+        resp = Mock(headers={"Retry-After": "30"})
+        assert client._handle_429(resp, "https://example.com") == 30.0
+
+    def test_retry_after_http_date(self):
+        client = self._make_client()
+        # Use a date 45 seconds in the future
+        future = datetime.now(timezone.utc).timestamp() + 45
+        future_dt = datetime.fromtimestamp(future, tz=timezone.utc)
+        http_date = future_dt.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        resp = Mock(headers={"Retry-After": http_date})
+        wait = client._handle_429(resp, "https://example.com")
+        # Allow 2s tolerance for test execution time
+        assert 43 <= wait <= 47
+
+    def test_ratelimit_reset_as_seconds(self):
+        client = self._make_client()
+        resp = Mock(headers={"RateLimit-Reset": "120"})
+        assert client._handle_429(resp, "https://example.com") == 120.0
+
+    @patch("pypaperretriever.http_client.time.time", return_value=1700000000.0)
+    def test_ratelimit_reset_as_unix_timestamp(self, _mock_time):
+        client = self._make_client()
+        resp = Mock(headers={"RateLimit-Reset": "1700000090"})
+        wait = client._handle_429(resp, "https://example.com")
+        assert abs(wait - 90.0) < 1.0
+
+    def test_x_ratelimit_reset_fallback(self):
+        client = self._make_client()
+        resp = Mock(headers={"X-RateLimit-Reset": "25"})
+        assert client._handle_429(resp, "https://example.com") == 25.0
+
+    def test_ratelimit_reset_preferred_over_x(self):
+        client = self._make_client()
+        resp = Mock(headers={
+            "RateLimit-Reset": "10",
+            "X-RateLimit-Reset": "99",
+        })
+        assert client._handle_429(resp, "https://example.com") == 10.0
+
+    def test_retry_after_preferred_over_ratelimit_reset(self):
+        client = self._make_client()
+        resp = Mock(headers={
+            "Retry-After": "5",
+            "RateLimit-Reset": "99",
+        })
+        assert client._handle_429(resp, "https://example.com") == 5.0
+
+    def test_default_fallback_when_no_headers(self):
+        client = self._make_client(default_retry_after_s=60.0)
+        resp = Mock(headers={})
+        assert client._handle_429(resp, "https://example.com") == 60.0
+
+    def test_custom_default_fallback(self):
+        client = self._make_client(default_retry_after_s=30.0)
+        resp = Mock(headers={})
+        assert client._handle_429(resp, "https://example.com") == 30.0
+
+    def test_max_retry_after_clamps_value(self):
+        client = self._make_client(max_retry_after_s=10.0)
+        resp = Mock(headers={"Retry-After": "600"})
+        assert client._handle_429(resp, "https://example.com") == 10.0
+
+    def test_unparseable_retry_after_falls_through(self):
+        client = self._make_client(default_retry_after_s=60.0)
+        resp = Mock(headers={"Retry-After": "not-a-number-or-date"})
+        assert client._handle_429(resp, "https://example.com") == 60.0
+
+
+# ---------------------------------------------------------------------------
+# HttpClient tests — 429 retry integration in get()
+# ---------------------------------------------------------------------------
+
+class TestHttpClient429Retry:
+    """Tests for the retry loop in HttpClient.get()."""
+
+    @patch("pypaperretriever.http_client.time.sleep")
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_retries_on_429_then_succeeds(self, mock_get, _mock_time, mock_sleep):
+        resp_429 = Mock(status_code=429, headers={"Retry-After": "2"})
+        resp_200 = Mock(status_code=200, headers={})
+        mock_get.side_effect = [resp_429, resp_200]
+
+        client = HttpClient(honor_retry_after=True, verbosity=0)
+        resp = client.get("https://example.com/page")
+
+        assert resp.status_code == 200
+        assert mock_get.call_count == 2
+        mock_sleep.assert_called_once_with(2.0)
+
+    @patch("pypaperretriever.http_client.time.sleep")
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_gives_up_after_max_retries(self, mock_get, _mock_time, mock_sleep):
+        resp_429 = Mock(status_code=429, headers={"Retry-After": "1"})
+        mock_get.return_value = resp_429
+
+        client = HttpClient(honor_retry_after=True, max_retries=3, verbosity=0)
+        resp = client.get("https://example.com/page")
+
+        assert resp.status_code == 429
+        # 1 initial + 3 retries = 4 calls
+        assert mock_get.call_count == 4
+        assert mock_sleep.call_count == 3
+
+    @patch("pypaperretriever.http_client.time.sleep")
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_no_retry_when_disabled(self, mock_get, _mock_time, mock_sleep):
+        resp_429 = Mock(status_code=429, headers={"Retry-After": "5"})
+        mock_get.return_value = resp_429
+
+        client = HttpClient(honor_retry_after=False, verbosity=0)
+        resp = client.get("https://example.com/page")
+
+        assert resp.status_code == 429
+        mock_get.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("pypaperretriever.http_client.time.sleep")
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_no_retry_on_non_429(self, mock_get, _mock_time, mock_sleep):
+        resp_500 = Mock(status_code=500, headers={})
+        mock_get.return_value = resp_500
+
+        client = HttpClient(honor_retry_after=True, verbosity=0)
+        resp = client.get("https://example.com/page")
+
+        assert resp.status_code == 500
+        mock_get.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("pypaperretriever.http_client.time.sleep")
+    @patch("pypaperretriever.http_client.time.time", return_value=100.0)
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_multiple_429s_then_success(self, mock_get, _mock_time, mock_sleep):
+        resp_429 = Mock(status_code=429, headers={"Retry-After": "1"})
+        resp_200 = Mock(status_code=200, headers={})
+        mock_get.side_effect = [resp_429, resp_429, resp_200]
+
+        client = HttpClient(honor_retry_after=True, max_retries=3, verbosity=0)
+        resp = client.get("https://example.com/page")
+
+        assert resp.status_code == 200
+        assert mock_get.call_count == 3
+        assert mock_sleep.call_count == 2

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,278 @@
+from unittest.mock import Mock, patch, MagicMock
+from urllib.robotparser import RobotFileParser
+
+import pytest
+
+from pypaperretriever.http_client import HttpClient, RobotsTxtCache
+
+
+# ---------------------------------------------------------------------------
+# RobotsTxtCache tests
+# ---------------------------------------------------------------------------
+
+class TestRobotsTxtCache:
+
+    def test_domain_key_extracts_scheme_and_netloc(self):
+        assert RobotsTxtCache._domain_key(
+            "https://example.com/some/path?q=1"
+        ) == "https://example.com"
+
+    def test_cache_returns_none_on_fetch_failure(self):
+        cache = RobotsTxtCache(user_agent="TestBot/1.0")
+        with patch.object(
+            RobotsTxtCache, "_fetch_robots_txt", return_value=None
+        ):
+            parser = cache.get_parser("https://broken.example.com/page")
+        assert parser is None
+
+    def test_cache_returns_parser_on_success(self):
+        rp = RobotFileParser()
+        cache = RobotsTxtCache(user_agent="TestBot/1.0")
+        with patch.object(
+            RobotsTxtCache, "_fetch_robots_txt", return_value=rp
+        ):
+            parser = cache.get_parser("https://good.example.com/page")
+        assert parser is rp
+
+    def test_cache_deduplicates_by_domain(self):
+        rp = RobotFileParser()
+        cache = RobotsTxtCache(user_agent="TestBot/1.0")
+        with patch.object(
+            RobotsTxtCache, "_fetch_robots_txt", return_value=rp
+        ) as mock_fetch:
+            cache.get_parser("https://example.com/page1")
+            cache.get_parser("https://example.com/page2")
+        mock_fetch.assert_called_once_with("https://example.com")
+
+    def test_can_fetch_returns_true_when_no_robots(self):
+        cache = RobotsTxtCache(user_agent="TestBot/1.0")
+        with patch.object(
+            RobotsTxtCache, "_fetch_robots_txt", return_value=None
+        ):
+            assert cache.can_fetch("https://example.com/anything") is True
+
+    def test_can_fetch_delegates_to_parser(self):
+        rp = Mock(spec=RobotFileParser)
+        rp.can_fetch.return_value = False
+        cache = RobotsTxtCache(user_agent="TestBot/1.0")
+        with patch.object(
+            RobotsTxtCache, "_fetch_robots_txt", return_value=rp
+        ):
+            result = cache.can_fetch("https://example.com/secret")
+        rp.can_fetch.assert_called_once_with(
+            "TestBot/1.0", "https://example.com/secret"
+        )
+        assert result is False
+
+    def test_crawl_delay_returns_value_when_present(self):
+        rp = Mock(spec=RobotFileParser)
+        rp.crawl_delay.return_value = 10
+        cache = RobotsTxtCache(user_agent="TestBot/1.0")
+        with patch.object(
+            RobotsTxtCache, "_fetch_robots_txt", return_value=rp
+        ):
+            delay = cache.crawl_delay("https://example.com/page")
+        assert delay == 10.0
+
+    def test_crawl_delay_returns_none_when_absent(self):
+        rp = Mock(spec=RobotFileParser)
+        rp.crawl_delay.return_value = None
+        cache = RobotsTxtCache(user_agent="TestBot/1.0")
+        with patch.object(
+            RobotsTxtCache, "_fetch_robots_txt", return_value=rp
+        ):
+            delay = cache.crawl_delay("https://example.com/page")
+        assert delay is None
+
+    def test_crawl_delay_returns_none_when_no_parser(self):
+        cache = RobotsTxtCache(user_agent="TestBot/1.0")
+        with patch.object(
+            RobotsTxtCache, "_fetch_robots_txt", return_value=None
+        ):
+            delay = cache.crawl_delay("https://example.com/page")
+        assert delay is None
+
+
+# ---------------------------------------------------------------------------
+# HttpClient tests — respect_robots_txt=False (pass-through mode)
+# ---------------------------------------------------------------------------
+
+class TestHttpClientPassthrough:
+
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_passthrough_returns_response(self, mock_get):
+        mock_get.return_value = Mock(status_code=200)
+        client = HttpClient(respect_robots_txt=False)
+        resp = client.get("https://example.com/data")
+        assert resp.status_code == 200
+        mock_get.assert_called_once()
+
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_passthrough_never_returns_none(self, mock_get):
+        mock_get.return_value = Mock(status_code=403)
+        client = HttpClient(respect_robots_txt=False)
+        resp = client.get("https://example.com/forbidden")
+        assert resp is not None
+
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_passthrough_forwards_kwargs(self, mock_get):
+        mock_get.return_value = Mock(status_code=200)
+        client = HttpClient(respect_robots_txt=False)
+        client.get("https://example.com", timeout=5, stream=True)
+        _, kwargs = mock_get.call_args
+        assert kwargs["timeout"] == 5
+        assert kwargs["stream"] is True
+
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_passthrough_sets_default_user_agent(self, mock_get):
+        mock_get.return_value = Mock(status_code=200)
+        client = HttpClient(
+            user_agent="MyBot/1.0", respect_robots_txt=False
+        )
+        client.get("https://example.com")
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["User-Agent"] == "MyBot/1.0"
+
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_passthrough_preserves_caller_headers(self, mock_get):
+        mock_get.return_value = Mock(status_code=200)
+        client = HttpClient(respect_robots_txt=False)
+        client.get(
+            "https://example.com",
+            headers={"User-Agent": "Custom/2.0", "Accept": "text/html"},
+        )
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["User-Agent"] == "Custom/2.0"
+        assert kwargs["headers"]["Accept"] == "text/html"
+
+    @patch("pypaperretriever.http_client.time.sleep")
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_passthrough_does_not_sleep(self, mock_get, mock_sleep):
+        mock_get.return_value = Mock(status_code=200)
+        client = HttpClient(respect_robots_txt=False)
+        client.get("https://example.com/a")
+        client.get("https://example.com/b")
+        mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# HttpClient tests — respect_robots_txt=True
+# ---------------------------------------------------------------------------
+
+class TestHttpClientWithRobots:
+
+    def _make_client(self, can_fetch=True, crawl_delay=None, **kwargs):
+        """Helper to create an HttpClient with a mocked RobotsTxtCache."""
+        client = HttpClient(
+            user_agent="TestBot/1.0",
+            respect_robots_txt=True,
+            verbosity=0,
+            **kwargs,
+        )
+        mock_cache = Mock(spec=RobotsTxtCache)
+        mock_cache.can_fetch.return_value = can_fetch
+        mock_cache.crawl_delay.return_value = crawl_delay
+        client._robots_cache = mock_cache
+        return client
+
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_returns_none_when_disallowed(self, mock_get):
+        client = self._make_client(can_fetch=False)
+        resp = client.get("https://example.com/secret")
+        assert resp is None
+        mock_get.assert_not_called()
+
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_returns_response_when_allowed(self, mock_get):
+        mock_get.return_value = Mock(status_code=200)
+        client = self._make_client(can_fetch=True)
+        resp = client.get("https://example.com/page")
+        assert resp is not None
+        assert resp.status_code == 200
+
+    @patch("pypaperretriever.http_client.time.sleep")
+    @patch("pypaperretriever.http_client.time.time")
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_applies_crawl_delay(self, mock_get, mock_time, mock_sleep):
+        mock_get.return_value = Mock(status_code=200)
+        # Simulate: first call at t=100, second call at t=100.5
+        mock_time.side_effect = [100.0, 100.5, 100.5]
+        client = self._make_client(crawl_delay=5.0)
+
+        client.get("https://example.com/page1")
+        client.get("https://example.com/page2")
+
+        # Should sleep 5.0 - 0.5 = 4.5 seconds
+        mock_sleep.assert_called_once()
+        actual_sleep = mock_sleep.call_args[0][0]
+        assert abs(actual_sleep - 4.5) < 0.01
+
+    @patch("pypaperretriever.http_client.time.sleep")
+    @patch("pypaperretriever.http_client.time.time")
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_fallback_delay_when_no_crawl_delay(
+        self, mock_get, mock_time, mock_sleep
+    ):
+        mock_get.return_value = Mock(status_code=200)
+        # Simulate: first call at t=100, second call immediately at t=100
+        mock_time.side_effect = [100.0, 100.0, 100.0]
+        client = self._make_client(
+            crawl_delay=None,
+            rate_limit_min_s=2.0,
+            rate_limit_max_s=2.0,  # Fixed for determinism
+        )
+
+        client.get("https://example.com/a")
+        client.get("https://example.com/b")
+
+        mock_sleep.assert_called_once()
+        actual_sleep = mock_sleep.call_args[0][0]
+        assert abs(actual_sleep - 2.0) < 0.01
+
+    @patch("pypaperretriever.http_client.time.sleep")
+    @patch("pypaperretriever.http_client.time.time")
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_no_sleep_on_first_request(
+        self, mock_get, mock_time, mock_sleep
+    ):
+        mock_get.return_value = Mock(status_code=200)
+        mock_time.return_value = 100.0
+        client = self._make_client(crawl_delay=10.0)
+
+        client.get("https://example.com/first")
+
+        mock_sleep.assert_not_called()
+
+    @patch("pypaperretriever.http_client.time.sleep")
+    @patch("pypaperretriever.http_client.time.time")
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_per_domain_delay_independence(
+        self, mock_get, mock_time, mock_sleep
+    ):
+        mock_get.return_value = Mock(status_code=200)
+        # Both calls happen "immediately"
+        mock_time.return_value = 100.0
+        client = self._make_client(crawl_delay=10.0)
+
+        # First request to domain A — no sleep (first for this domain)
+        client.get("https://a.example.com/page")
+        # First request to domain B — no sleep (first for this domain)
+        client.get("https://b.example.com/page")
+
+        mock_sleep.assert_not_called()
+
+    @patch("pypaperretriever.http_client.time.sleep")
+    @patch("pypaperretriever.http_client.time.time")
+    @patch("pypaperretriever.http_client.requests.get")
+    def test_no_sleep_when_enough_time_elapsed(
+        self, mock_get, mock_time, mock_sleep
+    ):
+        mock_get.return_value = Mock(status_code=200)
+        # First call at t=100, second call at t=200 (well past 5s delay)
+        mock_time.side_effect = [100.0, 200.0, 200.0]
+        client = self._make_client(crawl_delay=5.0)
+
+        client.get("https://example.com/page1")
+        client.get("https://example.com/page2")
+
+        mock_sleep.assert_not_called()

--- a/tests/test_paper_retriever.py
+++ b/tests/test_paper_retriever.py
@@ -69,7 +69,7 @@ def mock_entrez_efetch_pmid(*args, **kwargs):
     data = BytesIO(data.encode())
     return Entrez.read(data)
 
-@patch('pypaperretriever.paper_retriever.requests.get', side_effect=mock_requests_get)
+@patch('pypaperretriever.http_client.requests.get', side_effect=mock_requests_get)
 @patch('pypaperretriever.utils.entrez_efetch', side_effect=mock_entrez_efetch_doi)
 def test_fetch_paper_with_doi(mock_efetch, mock_get, tmp_path):
     """
@@ -112,7 +112,7 @@ def test_fetch_paper_with_doi(mock_efetch, mock_get, tmp_path):
         assert json_data['pdf_filepath'].endswith(str(expected_pdf_path).replace(str(tmp_path), ""))
         assert json_data['open_access'] is True
 
-@patch('pypaperretriever.paper_retriever.requests.get', side_effect=mock_requests_get)
+@patch('pypaperretriever.http_client.requests.get', side_effect=mock_requests_get)
 @patch('pypaperretriever.utils.entrez_efetch', side_effect=mock_entrez_efetch_pmid)
 def test_fetch_paper_with_pmid(mock_efetch, mock_get, tmp_path):
     """


### PR DESCRIPTION
Once a domain generates a 403 (Forbidden) error, treat all subsequent requests to that domain as if they all generate 403. This greatly speeds up bulk requests by dropping useless requests.

Note that doi.org is exempt. If there are other redirect-only domains, those can be added to the exception list.
